### PR TITLE
docs(o-agent): correct address scheme + cross-process daemon usage

### DIFF
--- a/packages/o-agent/README.md
+++ b/packages/o-agent/README.md
@@ -1,6 +1,6 @@
 # @olane/o-agent
 
-**Address**: `o://agents` (registry) and `o://<user>/<kind>/<session-id>` (per session)
+**Addresses**: `o://agents` (registry) — agent sessions get single-segment slugs (see "Address scheme" below)
 **Type**: Application Layer
 **Domain**: Multi-Agent / Coding Assistants
 
@@ -13,13 +13,18 @@ discover each other and exchange messages bidirectionally.
 
 The package ships:
 
-- **`AgentNode`** — one canonical address per session (e.g.
-  `o://brendon/claude-code/1234`). Sub-resources (`/inbox`, `/inbox/<id>`,
-  `/send`, `/card`, `/status`) are dispatched by an `oAgentResolver` that
-  mirrors the `o-storage` pattern verbatim.
+- **`AgentNode`** — a tool node that hosts one running session's inbox,
+  outbox, and capability card. Designed to run either in-process inside the
+  OS host OR as a per-session daemon that joins the network from a
+  separate process.
 - **`AgentRegistryNode`** — sibling registry mounted on the OS leader at
   `o://agents`. Tracks live sessions via heartbeat + PID liveness; sweeps
   stale entries on a 60-second timer (TTL = 90 s).
+- **`oAgentResolver`** — `oAddressResolver` subclass mirroring the
+  `o-storage` pattern; dispatches sub-paths under an AgentNode's
+  canonical address (`/inbox`, `/inbox/<id>`, `/send`, `/card`, `/status`,
+  …) to the matching tool method. **Fires inside the AgentNode's host
+  process only** — see "Cross-process callers" below.
 - **A2A-shaped envelopes** — `AgentCard`, `InboxMessage`, and `MessagePart`
   mirror the public Google A2A schemas so a future `o://a2a-bridge` HTTP
   node can serve `/.well-known/agent.json` and bridge tasks without
@@ -27,12 +32,48 @@ The package ships:
 
 ## Status
 
-**Phase 1, in progress.** This package currently exports only the type
-contracts (`AgentCard`, `InboxMessage`, `RegistryEntry`, `AgentKind`).
-`AgentNode`, `AgentRegistryNode`, and `oAgentResolver` land in subsequent PRs
-per the [ADR](../../../o-network-cli/docs/adr/0001-olane-agent-broker.md).
+**Phase 1, shipped.** All exports are stable: types, `oAgentResolver`,
+`AgentRegistryNode`, `AgentNode`. Wired into `@olane/os` startup so
+`o://agents` is a leader child by default.
 
-## Architecture (target)
+## Address scheme
+
+> **Constraint:** olane's cross-process registration (`oRegistrationManager`
+> → `leader._tool_child_register`) does not work with multi-segment
+> constructor addresses — path arithmetic during the join handshake
+> concatenates the daemon's path onto the leader address and the
+> registration call lands at a non-existent node. Every in-tree olane
+> node uses single-segment constructor addresses (`o://node`,
+> `o://services`, `o://relay`, `o://storage`, …) for the same reason.
+
+Per-session AgentNodes therefore use a **single-segment slug** that
+encodes the user, agent kind, and session id:
+
+```
+o://agent-<user>-<kind>-<session-id>
+```
+
+After the leader registers the daemon under its hierarchy, the effective
+address becomes:
+
+```
+o://leader/agent-<user>-<kind>-<session-id>
+```
+
+Use this prefixed form when calling `node.use(address, …)` from other
+agents or CLIs. The structured fields stay on the card for filtering and
+display:
+
+```ts
+card.olane = {
+  kind: 'claude-code',
+  sessionId: '1234',
+  user: 'brendon',
+  registeredAt: '2026-05-08T...',
+};
+```
+
+## Architecture
 
 ```
                         ┌───────────────────┐
@@ -49,20 +90,109 @@ per the [ADR](../../../o-network-cli/docs/adr/0001-olane-agent-broker.md).
                                  │  registers / heartbeats
                 ┌────────────────┼─────────────────┐
                 ▼                ▼                 ▼
-   o://brendon/         o://brendon/         o://brendon/
-   claude-code/1234     codex/abcd           claude-code/9999
-   AgentNode            AgentNode            AgentNode
+   o://leader/             o://leader/        o://leader/
+   agent-brendon-          agent-brendon-     agent-brendon-
+   claude-code-1234        codex-abcd         claude-code-9999
+   AgentNode               AgentNode          AgentNode
 ```
-
-Each `AgentNode` exposes its inbox, outbox, and card via sub-paths under its
-canonical address. Other agents (or external CLIs / MCP tools) call those
-addresses through `node.use()` like any other olane tool.
 
 ## Installation
 
 ```bash
 pnpm install @olane/o-agent
 ```
+
+## Cross-process daemon usage
+
+The most common deployment pattern: each coding-agent session has its own
+detached background process that hosts an `AgentNode`. The daemon joins
+the running OS as a libp2p worker.
+
+```ts
+import { AgentNode, AgentCard, AGENT_KIND_METADATA, AgentKind } from '@olane/o-agent';
+import { oNodeAddress, oNodeTransport } from '@olane/o-node';
+import * as fs from 'fs/promises';
+
+// 1. Read the running OS singleton's discovery file.
+const osInfo = JSON.parse(
+  await fs.readFile(`${process.env.HOME}/.olane/os.json`, 'utf8'),
+);
+
+// 2. Build a leader address with the OS's libp2p multiaddrs so we can
+//    dial it during start().
+const leaderAddress = new oNodeAddress(
+  osInfo.leaderAddress,                                  // 'o://leader'
+  osInfo.transports.map(m => new oNodeTransport(m)),
+);
+
+// 3. Construct the AgentNode at a SINGLE-SEGMENT slug.
+const card: AgentCard = {
+  name: 'Claude Code session 1234',
+  url: 'o://agent-brendon-claude-code-1234',
+  version: '1.0.0',
+  capabilities: { streaming: false, pushNotifications: false, stateTransitionHistory: false },
+  defaultInputModes: ['text'],
+  defaultOutputModes: ['text'],
+  skills: AGENT_KIND_METADATA[AgentKind.CLAUDE_CODE].defaultSkills.map(id => ({ id })),
+  olane: {
+    kind: AgentKind.CLAUDE_CODE,
+    sessionId: '1234',
+    user: 'brendon',
+    registeredAt: new Date().toISOString(),
+  },
+};
+
+const agent = new AgentNode({
+  address: new oNodeAddress('o://agent-brendon-claude-code-1234'),
+  leader: leaderAddress,
+  parent: leaderAddress,
+  // REQUIRED for cross-process daemons — libp2p must bind a port the
+  // leader can dial back through during routing. In-process AgentNodes
+  // (children of an in-process leader) do NOT need this.
+  network: {
+    listeners: ['/ip4/0.0.0.0/tcp/0'],
+  },
+  card,
+});
+
+await agent.start();
+// AgentNode auto-registers with `o://agents` and starts a 30s heartbeat.
+// Stays resident until SIGTERM; agent.stop() deregisters cleanly.
+```
+
+The daemon's effective address after registration is
+`o://leader/agent-brendon-claude-code-1234`. Other agents reach it via:
+
+```ts
+await someClient.use('o://leader/agent-brendon-claude-code-1234', {
+  method: 'receive',
+  params: { message: { id, from, to, sentAt, parts } },
+});
+```
+
+For a working end-to-end implementation see
+`@copass/cli` `src/commands/olane.ts` — the `register` / `_host` /
+`deregister` pattern that wraps this into Claude Code hook plumbing.
+
+## Cross-process callers — sub-paths vs. method params
+
+`oAgentResolver` translates sub-paths under an AgentNode's canonical
+address (`o://addr/inbox`, `o://addr/inbox/<id>`, `o://addr/send`, …)
+into method calls. **The resolver only fires inside the AgentNode's own
+process** because each `oNode` registers its resolvers on its own router
+during `initialize()` — the leader's resolver chain has no knowledge of
+sub-paths it doesn't own.
+
+This means:
+
+| Caller location | How to call AgentNode methods |
+|---|---|
+| **Same process** (e.g. another `oLaneTool` running alongside) | Either `use(canonical, { method: 'receive', params: ... })` or the sub-path form `use(canonical + '/receive', ...)` works — the resolver translates the second form to the first. |
+| **Different process** (CLI, separate daemon, MCP shellout) | Use `use(canonical, { method: 'receive', params: ... })`. Sub-path form **does not work** — the leader will return `node not found` because it tries to route to a literal `<canonical>/receive` node. |
+
+In-process sub-path resolution is still useful for ergonomic in-tree
+callers; cross-process consumers should use the explicit method-as-param
+form.
 
 ## License
 

--- a/packages/o-agent/src/agent/agent-node.tool.ts
+++ b/packages/o-agent/src/agent/agent-node.tool.ts
@@ -32,10 +32,27 @@ export interface AgentNodeConfig extends oNodeConfig {
 /**
  * `AgentNode` — one running coding-agent session on the local Olane OS.
  *
- * Each session is a flat `o://<user>/<kind>/<session-id>` address. Sub-paths
- * (`/inbox`, `/inbox/<id>`, `/send`, `/receive`, `/drain`, `/card`,
- * `/status`) dispatch to methods via the `oAgentResolver` registered in
- * `initialize()`.
+ * Address scheme: a SINGLE-segment slug encoding user / kind / session,
+ * typically `o://agent-<user>-<kind>-<session-id>`. Multi-segment
+ * constructor addresses break olane's cross-process registration
+ * (`oRegistrationManager` → `leader._tool_child_register` does path
+ * arithmetic that fails on nested addresses) — every in-tree olane node
+ * uses single-segment constructor addresses for the same reason. After
+ * the leader registers the AgentNode under its hierarchy, the effective
+ * address is `o://leader/<slug>`. Structured user/kind/sessionId fields
+ * are preserved on `card.olane` for filtering and display.
+ *
+ * Sub-paths (`/inbox`, `/inbox/<id>`, `/send`, `/receive`, `/drain`,
+ * `/card`, `/status`) dispatch to methods via the `oAgentResolver`
+ * registered in `initialize()`. **The resolver fires inside this node's
+ * own process only.** Cross-process callers should use the explicit
+ * method-as-param form: `node.use(canonical, { method: 'receive',
+ * params: ... })`. See README "Cross-process callers" section.
+ *
+ * Cross-process daemon usage (the most common pattern): pass
+ * `network.listeners: ['/ip4/0.0.0.0/tcp/0']` so libp2p binds a port the
+ * leader can dial back through during routing. In-process AgentNodes do
+ * NOT need this — see README "Cross-process daemon usage".
  *
  * Inbox is in-memory in Phase 1 (bounded ring buffer). Persistent
  * overflow is deferred to Phase 2 per ADR.


### PR DESCRIPTION
## Summary

Documentation polish for `@olane/o-agent` based on findings from end-to-end smoke testing against a running `OlaneOS` (in `olane-labs/o-cli` PR #2). The published package works correctly — these are doc inaccuracies and undocumented requirements that would trip up the next consumer.

## What's wrong with the published docs

1. **Address scheme is misleading.** The README + `AgentNode` docstring claim agents are addressed at `o://<user>/<kind>/<session-id>` (3 segments). This breaks cross-process registration — `oRegistrationManager` → `leader._tool_child_register` does path arithmetic that fails on nested constructor addresses (the `child_register` call lands at `o://leader/<user>/<kind>/<session-id>` which doesn't exist). Every in-tree olane node uses **single-segment constructor addresses** for the same reason (`o://node`, `o://services`, `o://relay`, `o://storage`, …).

2. **`network.listeners` requirement is undocumented.** Cross-process daemons must bind their own libp2p port so the leader can dial back through during routing. The `o-private-network/nodes/services` container pattern does this; `@olane/o-agent` users had no way to know.

3. **`oAgentResolver` scope is unclear.** The resolver fires inside the AgentNode's host process only — each `oNode` registers resolvers on its own router during `initialize()`. The leader's resolver chain has no knowledge of sub-paths it doesn't own, so cross-process callers calling `o://addr/receive` get `node not found`. Sub-path form only works in-process.

4. **Status was outdated** — said "Phase 1, in progress" but the package is fully shipped + wired into `@olane/os`.

## What this PR changes

- README's title-line, "Address scheme" section, "Architecture" diagram, and "Cross-process callers" comparison table all show the working single-segment slug form: `o://agent-<user>-<kind>-<session-id>` → leader prefix → `o://leader/agent-<user>-<kind>-<session-id>`.
- New "Cross-process daemon usage" section walks through a complete code example: read `~/.olane/os.json`, build leader address with multiaddrs, construct `AgentNode` with `network.listeners`, `start()`, auto-register.
- New "Cross-process callers — sub-paths vs. method params" section with a comparison table for in-process vs. cross-process call patterns.
- `AgentNode` class docstring updated with the same key facts so editor hovers stay correct.
- Status flipped to "Phase 1, shipped."

**No runtime changes.** All 35 unit tests still pass.

## Why not auto-set `network.listeners`?

Considered defaulting `'/ip4/0.0.0.0/tcp/0'` in the `AgentNode` constructor but rejected: in-process AgentNodes (children of an in-process leader) don't need it and would hit a needless port-bind. Documenting the requirement and showing it in the cross-process example is the right move.

## Test plan

- [x] `pnpm build` clean
- [x] `pnpm test` — 35/35 passing
- [ ] Reviewer confirms README example matches the working `@copass/cli` `src/commands/olane.ts` daemon pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)