### PR TITLE
feat(o-os): wire RelayNode flag + ship relay in defaultOSInstanceConfig

### DIFF
--- a/packages/o-os/src/o-olane-os/config/default.config.ts
+++ b/packages/o-os/src/o-olane-os/config/default.config.ts
@@ -2,7 +2,20 @@ import { DEFAULT_INSTANCE_PATH, NodeType, oAddress } from '@olane/o-core';
 import { OlaneOSConfig } from '../interfaces/o-os.config.js';
 import * as path from 'path';
 
-export const defaultOSInstanceConfig = (port: number): OlaneOSConfig => {
+export interface DefaultOSInstanceConfigOptions {
+  /**
+   * Mount a circuit-relay-v2 RelayNode as a leader child so other peers
+   * can dial through this OS. Defaults to `true` — opt out by passing
+   * `{ enableRelay: false }` for headless server-side usage.
+   */
+  enableRelay?: boolean;
+}
+
+export const defaultOSInstanceConfig = (
+  port: number,
+  options: DefaultOSInstanceConfigOptions = {},
+): OlaneOSConfig => {
+  const { enableRelay = true } = options;
   return {
     configFilePath: path.join(
       DEFAULT_INSTANCE_PATH,
@@ -33,6 +46,19 @@ export const defaultOSInstanceConfig = (port: number): OlaneOSConfig => {
         leader: null,
         parent: null,
       },
+      ...(enableRelay
+        ? [
+            {
+              type: NodeType.NODE,
+              address: new oAddress('o://relay'),
+              description:
+                'circuit-relay-v2 server for the OS — other peers dial through this',
+              leader: null,
+              parent: null,
+              relay: true,
+            },
+          ]
+        : []),
     ],
     lanes: [],
     inProgress: [],

--- a/packages/o-os/src/o-olane-os/o-os.ts
+++ b/packages/o-os/src/o-olane-os/o-os.ts
@@ -20,6 +20,7 @@ import { MemoryHarness } from '../memory/memory-harness.js';
 import { CopassVectorStoreTool } from '../vector-store/copass-vector-store.tool.js';
 import { FilesystemTool } from '../tools/filesystem.tool.js';
 import { AgentRegistryNode } from '@olane/o-agent';
+import { RelayNode } from '../nodes/relay-node.js';
 
 type OlaneOSNode = oLaneTool | oLeaderNode;
 export class OlaneOS extends oObject {
@@ -227,6 +228,30 @@ export class OlaneOS extends oObject {
         await leaderNode.start();
         await initCommonTools(leaderNode);
         this.leaders.push(leaderNode);
+      } else if ((node as any).relay === true) {
+        // Relay node — circuit-relay-v2 server. Mounted as a leader
+        // child so it lives at `o://relay` (or whatever address the
+        // config specifies) at the same hierarchy level as the
+        // o://fs / o://vector-store / o://world-manager services.
+        // The `relay` flag is declared in OSRelayNodeConfig
+        // (interfaces/o-os.config.ts:11) but was never wired —
+        // consumers like @copass/olane-agents had to spawn the OS
+        // and call `addNode(new RelayNode(...))` themselves, which
+        // attached the relay to a round-robin worker, not the leader.
+        this.logger.debug(
+          'Starting relay node: ' + node.address.toString(),
+        );
+        const relayNode = new RelayNode({
+          ...node,
+          address: node.address,
+          leader: this.rootLeader?.address || null,
+          parent: this.rootLeader?.address || null,
+        } as any);
+        (relayNode as any).onInitFinished(() => {
+          this.rootLeader?.addChildNode(relayNode as any);
+        });
+        await relayNode.start();
+        this.nodes.push(relayNode);
       } else {
         this.logger.debug(
           'Starting non-leader node: ' + node.address.toString(),


### PR DESCRIPTION
## Summary

Two-part fix that lets `@olane/os` ship a circuit-relay-v2 server **as a leader child** by default, and stops downstream consumers from re-implementing the relay-mount pattern incorrectly.

## Why

`OSRelayNodeConfig.relay` was declared in `o-os/src/o-olane-os/interfaces/o-os.config.ts:11` (a partial of `oNodeConfig`) but `OlaneOS.startNodes()` never branched on it. Downstream consumers (e.g. `@copass/olane-agents`) had no way to ship a relay through the canonical lifecycle, so they did this instead:

```ts
const { os } = await startOS(name, config);
const relay = new RelayNode({ leader: os.rootLeader?.address, parent: os.rootLeader?.address });
await os.addNode(relay);  // ← parents the relay under a round-robin NON-LEADER worker
```

`os.addNode()` (`o-os.ts:56-71`) routes the new node through `entryNode().addChildNode(node)`, where `entryNode()` is round-robin across `this.nodes` (worker nodes, not the leader). That's structurally inconsistent with `o://fs` / `o://vector-store` / `o://world-manager`, which all mount as **direct leader children** during `initOSServices()`.

## Changes

### 1. Wire `OSRelayNodeConfig.relay` in `OlaneOS.startNodes`

`o-os.ts` now branches when `node.relay === true`: instantiates `RelayNode` (instead of plain `oLaneTool`) and attaches it as a leader child via the standard `onInitFinished → rootLeader.addChildNode` flow. RelayNode's libp2p config (circuit-relay-v2 server + identify + ping) lights up automatically as part of its inherited `configure()`.

### 2. `defaultOSInstanceConfig` ships the relay by default

```ts
defaultOSInstanceConfig(port);                        // gets a relay
defaultOSInstanceConfig(port, { enableRelay: false }); // headless / server-side
```

The relay sits at `o://relay` — same address `RelayNode`'s default constructor uses.

## Backward compatibility

- **`defaultOSInstanceConfig(port)` callers** now get a relay node in their `nodes` list. No new port (relay binds via the same libp2p config); just a new address.
- **Consumers explicitly instantiating their own RelayNode** at `o://relay` will now collide with the default. Easy migration: drop the explicit RelayNode and let the OS mount it.
- **Headless deployments** that explicitly don't want relay capability: `defaultOSInstanceConfig(port, { enableRelay: false })`.

## Downstream wins

- `@copass/olane-agents` can delete its `runOlaneOSHost` body (~80 LoC) and call `runLocalOs` from `@copass/datasource-olane` directly. Tracked as a follow-up PR in `olane-labs/copass` after this lands + a 0.8.22 release.

## Test plan

- [x] `pnpm -F @olane/os build` clean
- [ ] Reviewer confirms RelayNode-as-leader-child mounts correctly (i.e. that calling `o://relay.identify` from any other peer round-trips through the leader)
- [ ] If `defaultOSInstanceConfig` is exercised in any in-tree test, confirm the new relay node doesn't break startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)