### PR TITLE
docs(o-agent): correct address-scheme rationale

### DIFF
--- a/packages/o-agent/README.md
+++ b/packages/o-agent/README.md
@@ -38,13 +38,25 @@ The package ships:
 
 ## Address scheme
 
-> **Constraint:** olane's cross-process registration (`oRegistrationManager`
-> → `leader._tool_child_register`) does not work with multi-segment
-> constructor addresses — path arithmetic during the join handshake
-> concatenates the daemon's path onto the leader address and the
-> registration call lands at a non-existent node. Every in-tree olane
-> node uses single-segment constructor addresses (`o://node`,
-> `o://services`, `o://relay`, `o://storage`, …) for the same reason.
+**olane convention:** node tools must declare exactly **one path segment**
+in their constructor address (e.g. `o://node`, `o://services`, `o://relay`,
+`o://storage`). Hierarchical addressing happens via either:
+
+- **Child-node registration** — a parent node registers per-instance
+  children via `_tool_child_register`. The leader/parent prefixes its
+  own path post-registration, yielding addresses like
+  `o://leader/agents/<id>`.
+- **In-node sub-path resolvers** — a node's `oAddressResolver` (e.g.
+  `oAgentResolver`, `oStorageResolver`) dispatches sub-paths under its
+  canonical address to local methods. Sub-paths are resolved
+  in-process; they don't manifest as additional nodes in the OS
+  hierarchy.
+
+Multi-segment constructor addresses are NOT a routing primitive and
+will not behave as intended even with `_allowNestedAddress: true`.
+That escape hatch exists for the limited cases where the OS itself
+constructs already-hierarchical addresses internally — not for
+arbitrary cross-process workers.
 
 Per-session AgentNodes therefore use a **single-segment slug** that
 encodes the user, agent kind, and session id:

--- a/packages/o-agent/src/agent/agent-node.tool.ts
+++ b/packages/o-agent/src/agent/agent-node.tool.ts
@@ -33,14 +33,14 @@ export interface AgentNodeConfig extends oNodeConfig {
  * `AgentNode` — one running coding-agent session on the local Olane OS.
  *
  * Address scheme: a SINGLE-segment slug encoding user / kind / session,
- * typically `o://agent-<user>-<kind>-<session-id>`. Multi-segment
- * constructor addresses break olane's cross-process registration
- * (`oRegistrationManager` → `leader._tool_child_register` does path
- * arithmetic that fails on nested addresses) — every in-tree olane node
- * uses single-segment constructor addresses for the same reason. After
- * the leader registers the AgentNode under its hierarchy, the effective
- * address is `o://leader/<slug>`. Structured user/kind/sessionId fields
- * are preserved on `card.olane` for filtering and display.
+ * typically `o://agent-<user>-<kind>-<session-id>`. olane convention:
+ * node tools declare exactly ONE path segment in their constructor
+ * address. Hierarchical routing happens via child-node registration or
+ * in-node sub-path resolvers (see README "Address scheme") — never via
+ * multi-segment constructor addresses. After the leader registers the
+ * AgentNode under its hierarchy, the effective address is
+ * `o://leader/<slug>`. Structured user/kind/sessionId fields are
+ * preserved on `card.olane` for filtering and display.
  *
  * Sub-paths (`/inbox`, `/inbox/<id>`, `/send`, `/receive`, `/drain`,
  * `/card`, `/status`) dispatch to methods via the `oAgentResolver`


### PR DESCRIPTION
## Summary

Corrects the framing in the `@olane/o-agent` README and `AgentNode` class docstring that landed in #199. The previous wording said the single-segment `o://agent-<user>-<kind>-<session-id>` slug was a workaround for a "path-arithmetic bug" in `oRegistrationManager.registerParent()`.

It isn't. Per maintainer feedback:

> Nodes should only specify one segment during config. Their child paths are either other registered nodes (each with single-segment addresses) or resolvable via the node's internal routing logic. During config, node tools need exactly 1 segment defined. Example: `o://user123`.

Single-segment constructor addresses are the **olane convention**. `_allowNestedAddress: true` exists for the limited cases where the OS itself constructs already-hierarchical addresses (e.g. `o://os-config`, the leader's own `o://leader/<child>` post-registration hierarchy) — not for arbitrary cross-process workers picking multi-segment paths.

## Changes

- `packages/o-agent/README.md` — "Address scheme" section reframed:
  - Drops the "Constraint" callout about path arithmetic
  - Adds a positive description of the convention plus the two canonical paths to hierarchical addressing (child-registration vs. in-node sub-path resolvers)
- `packages/o-agent/src/agent/agent-node.tool.ts` — class docstring drops the "breaks cross-process registration" claim; reframes single-segment as the convention.

The runtime behavior is unchanged. The slug shipped in #199 was always correct; only the explanation was wrong.

## Closes

- olane-labs/olane#201 (filed in error — closed with apology)

🤖 Generated with [Claude Code](https://claude.com/claude-code)