### PR TITLE
feat(o-gateway-registry): scaffold v0 package skeleton (ADR 0025)

### DIFF
--- a/packages/o-gateway-registry/LICENSE
+++ b/packages/o-gateway-registry/LICENSE
@@ -1,0 +1,34 @@
+# Dual License: MIT OR Apache-2.0
+
+Copyright (c) 2025 Olane Inc.
+
+Olane OS is dual-licensed under your choice of either:
+
+- **MIT License** (LICENSE-MIT or https://opensource.org/licenses/MIT)
+- **Apache License, Version 2.0** (LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0)
+
+## Why Dual Licensing?
+
+Dual licensing provides developers with flexibility when integrating Olane OS into their projects:
+
+- **Choose MIT**: If you prefer a simple, permissive license without patent provisions
+- **Choose Apache 2.0**: If you desire explicit patent protection and other features of the Apache license
+
+You may choose either license to govern your use of this software.
+
+## License Terms
+
+### MIT License
+The MIT license is very permissive and allows users to do almost anything with the software, including using, copying, modifying, merging, publishing, distributing, and selling it. The primary requirement is that the original copyright and license notice must be included in all copies of the software.
+
+See LICENSE-MIT for the full license text.
+
+### Apache License 2.0
+The Apache License 2.0 is also a permissive free software license. It grants users the right to use, modify, and distribute the software. It also includes provisions regarding patent grants, which are not present in the MIT license.
+
+See LICENSE-APACHE for the full license text.
+
+## Contributing
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you shall be dual-licensed as above, without any additional terms or conditions.
+

--- a/packages/o-gateway-registry/README.md
+++ b/packages/o-gateway-registry/README.md
@@ -1,0 +1,72 @@
+# `@olane/o-gateway-registry`
+
+Public-good gateway registry resolver for `o://` addresses.
+
+> ADR: [`0025-public-good-gateway-registry.md`](https://github.com/olane-labs/o-twin-data-pipeline/blob/staging/docs/adr/0025-public-good-gateway-registry.md)
+
+This package resolves the **first path segment** of an `o://` address — the
+gateway namespace — to a libp2p multiaddr by reading a pinned snapshot of
+the public-good registry at `github.com/olane-labs/gateway-registry`.
+
+```
+o://meta/brendon/shell
+   └──┘  ← this segment is what we resolve
+```
+
+## Why a registry
+
+Today, `o://` resolves through a single hard-coded gateway (`o://olane` →
+`leader.olane.com`). One gateway is a product, not a network. The registry
+layer is the substrate that lets multiple operators host slices of the
+network — Meta, Anthropic, an enterprise on its own infrastructure, an
+indie hacker on a Raspberry Pi — each authoritative for their own users,
+all rooted in a common, auditable, mirror-able directory.
+
+Trust comes from the operator's verifiable DID, not from a centralized
+authority. Olane Inc. operates `o://olane` as one entry among many; we do
+not own the namespace.
+
+## Status: scaffold
+
+This first PR (skeleton) lands:
+
+- `interfaces/registry-entry.ts` — `GatewayRegistryEntry`, `SignatureBlock`
+- `interfaces/registry-snapshot.ts` — `RegistrySnapshot`, `SnapshotSignature`
+- `interfaces/resolver-config.ts` — `GatewayRegistryResolverConfig`
+- `registry/reserved-names.ts` — `RESERVED_GATEWAY_NAMES`, `isReservedGatewayName`, `validateGatewayName`
+- Tests for the naming policy
+
+The resolver itself (`GatewayRegistryResolver`) lands in the next PR. The
+`did:web` resolver and signature verification land in the PR after.
+End-to-end smoke is the final PR in the v0 chain.
+
+See [ADR 0025 §"Phasing"][adr-phasing] for the full sequence and
+[ADR 0025 §"Resolution Flow"][adr-flow] for the on-the-wire walkthrough
+of `o://meta/brendon/shell` → libp2p stream.
+
+[adr-phasing]: https://github.com/olane-labs/o-twin-data-pipeline/blob/staging/docs/adr/0025-public-good-gateway-registry.md#phasing
+[adr-flow]: https://github.com/olane-labs/o-twin-data-pipeline/blob/staging/docs/adr/0025-public-good-gateway-registry.md#resolution-flow--concrete-walk-through
+
+## Naming policy (locked by ADR 0025)
+
+A gateway name is:
+
+- Lowercase ASCII letters, digits, and hyphens
+- 2–63 characters (DNS-label compatible — keeps `did:web` upgrades cheap)
+- No leading or trailing hyphen
+- Not a reserved name
+
+Reserved: `olane`, `localhost`, `local`, `leader`, `lane`, `registry`,
+`internal`, and any single-character name.
+
+Use `validateGatewayName(name)` in your registration tooling — it returns
+`null` for valid names and a human-readable reason string otherwise.
+
+## Where the work lives
+
+| Artifact | Repo |
+|---|---|
+| This package (resolver, types) | `olane-labs/olane` (this monorepo) |
+| The registry data (signed JSON entries, schema, CODEOWNERS) | `olane-labs/gateway-registry` (separate public repo) |
+| The ADR | `olane-labs/o-twin-data-pipeline` (`docs/adr/0025-...`) |
+| Operator publication ceremony | PR against `olane-labs/gateway-registry` |

--- a/packages/o-gateway-registry/eslint.config.js
+++ b/packages/o-gateway-registry/eslint.config.js
@@ -1,0 +1,49 @@
+const { defineConfig, globalIgnores } = require('eslint/config');
+
+const tsParser = require('@typescript-eslint/parser');
+const typescriptEslintEslintPlugin = require('@typescript-eslint/eslint-plugin');
+const globals = require('globals');
+const js = require('@eslint/js');
+
+const { FlatCompat } = require('@eslint/eslintrc');
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all,
+});
+
+module.exports = defineConfig([
+  {
+    languageOptions: {
+      parser: tsParser,
+
+      globals: {
+        ...globals.jest,
+      },
+    },
+
+    plugins: {
+      '@typescript-eslint': typescriptEslintEslintPlugin,
+    },
+
+    extends: compat.extends(
+      'plugin:@typescript-eslint/recommended',
+      'plugin:prettier/recommended',
+    ),
+
+    rules: {
+      '@typescript-eslint/interface-name-prefix': 'off',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unused-vars': 'off',
+      '@typescript-eslint/ban-ts-comment': 'off',
+      '@typescript-eslint/no-var-requires': 'off',
+      'react/display-name': 'off',
+      'prettier/prettier': 'error',
+      '@typescript-eslint/no-empty-object-type': 'off',
+    },
+  },
+  globalIgnores(['**/.eslintrc.js']),
+]);

--- a/packages/o-gateway-registry/jest.config.cjs
+++ b/packages/o-gateway-registry/jest.config.cjs
@@ -1,0 +1,28 @@
+/**
+ * Jest configuration for an ESM TypeScript package.
+ *
+ * The package is `"type": "module"`, so the jest config itself must be
+ * `.cjs` for jest to load it via `require()`. ts-jest's ESM preset
+ * handles the `.js` import-extension convention used in source files.
+ */
+module.exports = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    // Source uses `'./foo.js'` import extensions per ESM spec, but the
+    // actual files on disk are `.ts`. Map them back during resolution.
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        useESM: true,
+        tsconfig: '<rootDir>/tsconfig.json',
+      },
+    ],
+  },
+  testMatch: ['<rootDir>/test/**/*.test.ts'],
+  testTimeout: 30000,
+};

--- a/packages/o-gateway-registry/package.json
+++ b/packages/o-gateway-registry/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@olane/o-gateway-registry",
+  "version": "0.9.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist/**/*",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
+    "dev": "DEBUG=o-protocol:* npx tsx src/tests/index.ts",
+    "build": "tsc",
+    "deep:clean": "rm -rf node_modules && rm package-lock.json",
+    "start:prod": "node dist/index.js",
+    "prepublishOnly": "npm run build",
+    "lint": "eslint src/**/*.ts"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/olane-labs/olane.git"
+  },
+  "author": "oLane Inc.",
+  "license": "(MIT OR Apache-2.0)",
+  "description": "Public-good gateway registry resolver for o:// addresses (ADR 0025). Resolves the first path segment (gateway namespace) to a libp2p multiaddr by reading a pinned snapshot of the olane-labs/gateway-registry public registry.",
+  "devDependencies": {
+    "@eslint/eslintrc": "^3.3.4",
+    "@eslint/js": "^10.0.1",
+    "@tsconfig/node20": "^20.1.9",
+    "@types/jest": "^30.0.0",
+    "@typescript-eslint/eslint-plugin": "^8.56.1",
+    "@typescript-eslint/parser": "^8.56.1",
+    "eslint": "^10.0.2",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-prettier": "^5.5.5",
+    "globals": "^17.3.0",
+    "jest": "^30.2.0",
+    "prettier": "^3.8.1",
+    "ts-jest": "^29.4.6",
+    "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0",
+    "tsx": "^4.21.0",
+    "typescript": "5.9.3"
+  },
+  "dependencies": {
+    "@olane/o-config": "0.9.0",
+    "@olane/o-core": "0.9.0",
+    "@olane/o-gateway-interface": "0.9.0",
+    "@olane/o-protocol": "0.9.0",
+    "debug": "^4.4.3",
+    "dotenv": "^17.3.1"
+  }
+}

--- a/packages/o-gateway-registry/src/index.ts
+++ b/packages/o-gateway-registry/src/index.ts
@@ -1,0 +1,2 @@
+export * from './interfaces/index.js';
+export * from './registry/index.js';

--- a/packages/o-gateway-registry/src/interfaces/index.ts
+++ b/packages/o-gateway-registry/src/interfaces/index.ts
@@ -1,0 +1,3 @@
+export * from './registry-entry.js';
+export * from './registry-snapshot.js';
+export * from './resolver-config.js';

--- a/packages/o-gateway-registry/src/interfaces/registry-entry.ts
+++ b/packages/o-gateway-registry/src/interfaces/registry-entry.ts
@@ -1,0 +1,70 @@
+import { oGateway } from '@olane/o-gateway-interface';
+
+/**
+ * A single gateway entry in the public-good registry.
+ *
+ * One entry per top-level `o://<name>` namespace. Each entry is signed by
+ * the operator's DID-bound key; v0 uses `did:web` (resolves through DNS to
+ * a `.well-known/did.json`) with a documented upgrade path to `did:plc`
+ * for v1.
+ *
+ * The on-disk shape (signed JSON) and the in-memory shape diverge by one
+ * field: on disk, `signature` is required; in memory after verification,
+ * `verifiedAt` is populated. Resolvers SHOULD never expose unverified
+ * entries to callers.
+ */
+export interface GatewayRegistryEntry extends oGateway {
+  /** First path segment under `o://`. Lowercase ASCII, single segment, no dots. */
+  name: string;
+
+  /** DID URI identifying the operator. v0: `did:web:...`. v1: `did:web:...` or `did:plc:...`. */
+  operatorDid: string;
+
+  /**
+   * libp2p multiaddrs the gateway can be dialed at. Order is the operator's
+   * advertised preference; clients SHOULD attempt in order with reasonable
+   * back-off.
+   */
+  transports: string[];
+
+  /** Free-text description shown in `olane gateway list`. */
+  description: string;
+
+  /** Operator logo URL (optional, advisory only). */
+  logo: string;
+
+  /** Operator website URL (optional, advisory only). */
+  website: string;
+
+  /**
+   * Capability classification per ADR 0025 §"Trust & Governance" and the
+   * v2 essay's seventh property. v0 only requires `read-only`/`side-effecting`/
+   * `irreversible`/`high-risk` at the gateway level; per-tool classification
+   * lands in v1.
+   */
+  defaultCapabilityClass:
+    | 'read-only'
+    | 'side-effecting'
+    | 'irreversible'
+    | 'high-risk';
+
+  /** ISO-8601 timestamp the entry was first published or last updated. */
+  publishedAt: string;
+
+  /** Detached signature over the canonicalized entry, by the operator's DID-bound key. */
+  signature: SignatureBlock;
+
+  /** Populated post-verification by the resolver; never present on disk. */
+  verifiedAt?: string;
+}
+
+export interface SignatureBlock {
+  /** DID URL fragment identifying which key in the DID document signed the entry. */
+  keyId: string;
+
+  /** Signature algorithm. v0 only supports `Ed25519`. */
+  algorithm: 'Ed25519';
+
+  /** Base64-encoded signature bytes. */
+  value: string;
+}

--- a/packages/o-gateway-registry/src/interfaces/registry-snapshot.ts
+++ b/packages/o-gateway-registry/src/interfaces/registry-snapshot.ts
@@ -1,0 +1,44 @@
+import { GatewayRegistryEntry } from './registry-entry.js';
+
+/**
+ * A pinned snapshot of the public-good registry at a specific commit.
+ *
+ * Clients fetch a snapshot, verify each entry's signature against its
+ * operator DID, and cache the result. The whole snapshot is itself signed
+ * by the registry-maintainer key (Olane Inc. for v0; rotated to a neutral
+ * foundation key in v3 per ADR 0025 phasing).
+ *
+ * The snapshot is the unit of mirroring: any party can serve a verbatim
+ * copy and a client can verify it independently of which mirror it came
+ * from.
+ */
+export interface RegistrySnapshot {
+  /** Schema version of the snapshot format. v0 = 1. */
+  schemaVersion: 1;
+
+  /** Commit hash in olane-labs/gateway-registry that this snapshot pins to. */
+  pinnedCommit: string;
+
+  /** ISO-8601 timestamp the snapshot was assembled. */
+  generatedAt: string;
+
+  /** All gateway entries at the pinned commit. */
+  entries: GatewayRegistryEntry[];
+
+  /** Detached signature by the registry-maintainer key over the canonicalized snapshot. */
+  maintainerSignature: SnapshotSignature;
+}
+
+export interface SnapshotSignature {
+  /** DID identifying the registry maintainer at signing time. */
+  maintainerDid: string;
+
+  /** DID URL fragment identifying the signing key. */
+  keyId: string;
+
+  /** Signature algorithm. v0 only supports `Ed25519`. */
+  algorithm: 'Ed25519';
+
+  /** Base64-encoded signature bytes. */
+  value: string;
+}

--- a/packages/o-gateway-registry/src/interfaces/resolver-config.ts
+++ b/packages/o-gateway-registry/src/interfaces/resolver-config.ts
@@ -1,0 +1,40 @@
+/**
+ * Construction-time configuration for `GatewayRegistryResolver`.
+ *
+ * Two layers of pinning, both required:
+ *   1. `snapshotUrl` — where to fetch the signed snapshot from (HTTPS).
+ *      Mirrors are allowed; the snapshot signature, not the URL, is what
+ *      the resolver trusts.
+ *   2. `expectedMaintainerDid` — the DID whose signature the resolver
+ *      requires on the snapshot. Pins trust to a specific maintainer
+ *      identity rather than to the hosting URL.
+ */
+export interface GatewayRegistryResolverConfig {
+  /** HTTPS URL serving the signed registry snapshot JSON. */
+  snapshotUrl: string;
+
+  /** DID URI of the registry maintainer whose signature is required on the snapshot. */
+  expectedMaintainerDid: string;
+
+  /**
+   * Local filesystem path to cache the verified snapshot at. If unset, no
+   * disk caching — the resolver fetches on every cold start. Recommended
+   * for production, optional for tests.
+   */
+  cachePath?: string;
+
+  /**
+   * Maximum age of the cached snapshot before a re-fetch is required, in
+   * milliseconds. Default 1 hour. Stale snapshots are kept usable past
+   * this if the network is unreachable; freshness is best-effort, not
+   * mandatory.
+   */
+  maxCacheAgeMs?: number;
+
+  /**
+   * If true, the resolver refuses to start when the snapshot signature
+   * does not verify. If false, it falls back to the legacy `o://olane`
+   * default and emits a warning. Default true. Only set false in tests.
+   */
+  failClosed?: boolean;
+}

--- a/packages/o-gateway-registry/src/registry/index.ts
+++ b/packages/o-gateway-registry/src/registry/index.ts
@@ -1,0 +1,1 @@
+export * from './reserved-names.js';

--- a/packages/o-gateway-registry/src/registry/reserved-names.ts
+++ b/packages/o-gateway-registry/src/registry/reserved-names.ts
@@ -1,0 +1,85 @@
+/**
+ * Top-level gateway namespaces that cannot be claimed by an operator.
+ *
+ * Locked by ADR 0025 §"Naming Policy". The list is intentionally small —
+ * each entry has a concrete reason for the carve-out (collides with an
+ * existing routing primitive, or is the legacy default, or is reserved
+ * for the substrate itself).
+ *
+ * Names are compared lowercase. The registry build also rejects any
+ * gateway name that is exactly one ASCII letter or digit, on the same
+ * grounds as DNS reserves single-letter SLDs — they are too scarce to
+ * allocate first-come-first-served.
+ */
+export const RESERVED_GATEWAY_NAMES: readonly string[] = [
+  // Legacy default. Keeps `o://olane` resolving to the historical leader
+  // until the deprecation timeline (its own follow-up ADR) is locked.
+  'olane',
+
+  // Localhost-equivalents. Reserved for client-side routing rules that
+  // never traverse the public registry.
+  'localhost',
+  'local',
+
+  // Collides with the `o://leader` restricted address inside o-core.
+  'leader',
+
+  // Collides with the `o://lane` runtime / `oLaneTool` namespace.
+  'lane',
+
+  // Reserved for any future substrate-internal addressing (e.g. a
+  // resolver-of-resolvers, snapshot index, or v3 governance directory).
+  'registry',
+
+  // Reserved for any internal-only routing the substrate may need to
+  // express (e.g. callback-only addresses).
+  'internal',
+] as const;
+
+/**
+ * Returns true if `name` is reserved and cannot be claimed as a top-level
+ * gateway namespace. Comparison is case-insensitive; the registry only
+ * accepts lowercase ASCII for new entries (ADR 0025 §"Naming Policy"),
+ * but reservation enforcement is permissive on input case.
+ */
+export function isReservedGatewayName(name: string): boolean {
+  const normalized = name.toLowerCase();
+  if (RESERVED_GATEWAY_NAMES.includes(normalized)) {
+    return true;
+  }
+  // Single-character names — too scarce to allocate first-come-first-served.
+  if (/^[a-z0-9]$/.test(normalized)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Validates a gateway name for v0 publication. Returns null if valid, or
+ * a human-readable rejection reason. Locked by ADR 0025 §"Naming Policy":
+ *   - lowercase ASCII letters, digits, hyphens
+ *   - 2–63 characters (DNS-label compatible to keep did:web upgrades cheap)
+ *   - no leading or trailing hyphen
+ *   - not a reserved name
+ *
+ * IDN / unicode is explicitly out of scope for v0 — flagged for a later
+ * ADR if adoption data shows the floor is binding.
+ */
+export function validateGatewayName(name: string): string | null {
+  if (typeof name !== 'string' || name.length === 0) {
+    return 'gateway name is empty';
+  }
+  if (name.length < 2) {
+    return 'gateway name must be at least 2 characters (single-character names are reserved)';
+  }
+  if (name.length > 63) {
+    return 'gateway name must be at most 63 characters (DNS-label compatible)';
+  }
+  if (!/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(name)) {
+    return 'gateway name must be lowercase ASCII letters, digits, and hyphens, with no leading or trailing hyphen';
+  }
+  if (isReservedGatewayName(name)) {
+    return `gateway name "${name}" is reserved and cannot be claimed`;
+  }
+  return null;
+}

--- a/packages/o-gateway-registry/test/reserved-names.test.ts
+++ b/packages/o-gateway-registry/test/reserved-names.test.ts
@@ -1,0 +1,87 @@
+import {
+  RESERVED_GATEWAY_NAMES,
+  isReservedGatewayName,
+  validateGatewayName,
+} from '../src/registry/reserved-names.js';
+
+describe('reserved gateway names', () => {
+  test('the legacy "olane" namespace is reserved', () => {
+    expect(isReservedGatewayName('olane')).toBe(true);
+  });
+
+  test('reservation is case-insensitive', () => {
+    expect(isReservedGatewayName('OLANE')).toBe(true);
+    expect(isReservedGatewayName('Olane')).toBe(true);
+  });
+
+  test('all documented reservations are flagged', () => {
+    for (const name of RESERVED_GATEWAY_NAMES) {
+      expect(isReservedGatewayName(name)).toBe(true);
+    }
+  });
+
+  test('single-character names are reserved (too scarce to allocate)', () => {
+    expect(isReservedGatewayName('a')).toBe(true);
+    expect(isReservedGatewayName('z')).toBe(true);
+    expect(isReservedGatewayName('0')).toBe(true);
+    expect(isReservedGatewayName('9')).toBe(true);
+  });
+
+  test('a normal two-character name is not reserved', () => {
+    expect(isReservedGatewayName('ab')).toBe(false);
+    expect(isReservedGatewayName('meta')).toBe(false);
+    expect(isReservedGatewayName('your-grandma')).toBe(false);
+  });
+});
+
+describe('validateGatewayName', () => {
+  test('accepts the canonical examples from ADR 0025', () => {
+    expect(validateGatewayName('meta')).toBeNull();
+    expect(validateGatewayName('your-grandma')).toBeNull();
+    expect(validateGatewayName('acme-corp')).toBeNull();
+  });
+
+  test('rejects empty input', () => {
+    expect(validateGatewayName('')).toMatch(/empty/);
+  });
+
+  test('rejects single-character names', () => {
+    expect(validateGatewayName('x')).toMatch(/at least 2/);
+  });
+
+  test('rejects names longer than 63 characters', () => {
+    const tooLong = 'a'.repeat(64);
+    expect(validateGatewayName(tooLong)).toMatch(/at most 63/);
+  });
+
+  test('rejects uppercase', () => {
+    expect(validateGatewayName('Meta')).toMatch(/lowercase/);
+  });
+
+  test('rejects underscore (DNS-label compatibility)', () => {
+    expect(validateGatewayName('foo_bar')).toMatch(/lowercase ASCII/);
+  });
+
+  test('rejects leading hyphen', () => {
+    expect(validateGatewayName('-meta')).toMatch(/leading or trailing hyphen/);
+  });
+
+  test('rejects trailing hyphen', () => {
+    expect(validateGatewayName('meta-')).toMatch(/leading or trailing hyphen/);
+  });
+
+  test('rejects reserved names with the reservation reason', () => {
+    expect(validateGatewayName('olane')).toMatch(/reserved/);
+    expect(validateGatewayName('leader')).toMatch(/reserved/);
+    expect(validateGatewayName('registry')).toMatch(/reserved/);
+  });
+
+  test('accepts hyphens in the interior', () => {
+    expect(validateGatewayName('a-b-c')).toBeNull();
+  });
+
+  test('accepts digits', () => {
+    expect(validateGatewayName('meta2')).toBeNull();
+    expect(validateGatewayName('v3')).toBeNull();
+  });
+});

--- a/packages/o-gateway-registry/tsconfig.json
+++ b/packages/o-gateway-registry/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@tsconfig/node20/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "declarationDir": "./dist",
+    "emitDeclarationOnly": false,
+    "module": "ESNext",
+    "target": "ES2020",
+    "moduleResolution": "node"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/tests", "webpack.config.js"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,20 +88,20 @@ importers:
   packages/o-agent:
     dependencies:
       '@olane/o-core':
-        specifier: 0.8.20
-        version: link:../o-core
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-lane':
-        specifier: 0.8.20
-        version: link:../o-lane
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-node':
-        specifier: 0.8.20
-        version: link:../o-node
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-protocol':
-        specifier: 0.8.20
-        version: link:../o-protocol
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-tool':
-        specifier: 0.8.20
-        version: link:../o-tool
+        specifier: 0.9.0
+        version: 0.9.0
       debug:
         specifier: ^4.4.3
         version: 4.4.3(supports-color@8.1.1)
@@ -170,23 +170,23 @@ importers:
   packages/o-approval:
     dependencies:
       '@olane/o-config':
-        specifier: 0.8.20
-        version: link:../o-config
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-core':
-        specifier: 0.8.20
-        version: link:../o-core
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-lane':
-        specifier: 0.8.20
-        version: link:../o-lane
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-node':
-        specifier: 0.8.20
-        version: link:../o-node
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-protocol':
-        specifier: 0.8.20
-        version: link:../o-protocol
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-tool':
-        specifier: 0.8.20
-        version: link:../o-tool
+        specifier: 0.9.0
+        version: 0.9.0
       debug:
         specifier: ^4.4.3
         version: 4.4.3(supports-color@8.1.1)
@@ -252,20 +252,20 @@ importers:
   packages/o-client-limited:
     dependencies:
       '@olane/o-config':
-        specifier: 0.8.20
-        version: link:../o-config
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-core':
-        specifier: 0.8.20
-        version: link:../o-core
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-node':
-        specifier: 0.8.20
-        version: link:../o-node
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-protocol':
-        specifier: 0.8.20
-        version: link:../o-protocol
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-tool':
-        specifier: 0.8.20
-        version: link:../o-tool
+        specifier: 0.9.0
+        version: 0.9.0
       debug:
         specifier: ^4.4.3
         version: 4.4.3(supports-color@8.1.1)
@@ -533,14 +533,14 @@ importers:
   packages/o-core:
     dependencies:
       '@olane/o-config':
-        specifier: 0.8.20
-        version: link:../o-config
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-context':
-        specifier: 0.8.20
-        version: link:../o-context
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-protocol':
-        specifier: 0.8.20
-        version: link:../o-protocol
+        specifier: 0.9.0
+        version: 0.9.0
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -624,17 +624,17 @@ importers:
   packages/o-gateway-interface:
     dependencies:
       '@olane/o-config':
-        specifier: 0.8.20
-        version: link:../o-config
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-core':
-        specifier: 0.8.20
-        version: link:../o-core
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-protocol':
-        specifier: 0.8.20
-        version: link:../o-protocol
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-tool':
-        specifier: 0.8.20
-        version: link:../o-tool
+        specifier: 0.9.0
+        version: 0.9.0
       debug:
         specifier: ^4.4.3
         version: 4.4.3(supports-color@8.1.1)
@@ -697,20 +697,93 @@ importers:
   packages/o-gateway-olane:
     dependencies:
       '@olane/o-config':
-        specifier: 0.8.20
-        version: link:../o-config
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-core':
-        specifier: 0.8.20
-        version: link:../o-core
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-node':
-        specifier: 0.8.20
-        version: link:../o-node
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-protocol':
-        specifier: 0.8.20
-        version: link:../o-protocol
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-tool':
-        specifier: 0.8.20
-        version: link:../o-tool
+        specifier: 0.9.0
+        version: 0.9.0
+      debug:
+        specifier: ^4.4.3
+        version: 4.4.3(supports-color@8.1.1)
+      dotenv:
+        specifier: ^17.3.1
+        version: 17.4.2
+    devDependencies:
+      '@eslint/eslintrc':
+        specifier: ^3.3.4
+        version: 3.3.5
+      '@eslint/js':
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@10.2.0(jiti@1.21.7))
+      '@tsconfig/node20':
+        specifier: ^20.1.9
+        version: 20.1.9
+      '@types/jest':
+        specifier: ^30.0.0
+        version: 30.0.0
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.56.1
+        version: 8.58.2(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@1.21.7))(typescript@5.9.3))(eslint@10.2.0(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/parser':
+        specifier: ^8.56.1
+        version: 8.58.2(eslint@10.2.0(jiti@1.21.7))(typescript@5.9.3)
+      eslint:
+        specifier: ^10.0.2
+        version: 10.2.0(jiti@1.21.7)
+      eslint-config-prettier:
+        specifier: ^10.1.8
+        version: 10.1.8(eslint@10.2.0(jiti@1.21.7))
+      eslint-plugin-prettier:
+        specifier: ^5.5.5
+        version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@10.2.0(jiti@1.21.7)))(eslint@10.2.0(jiti@1.21.7))(prettier@3.8.3)
+      globals:
+        specifier: ^17.3.0
+        version: 17.5.0
+      jest:
+        specifier: ^30.2.0
+        version: 30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3))
+      prettier:
+        specifier: ^3.8.1
+        version: 3.8.3
+      ts-jest:
+        specifier: ^29.4.6
+        version: 29.4.9(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3)))(typescript@5.9.3)
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@25.6.0)(typescript@5.9.3)
+      tsconfig-paths:
+        specifier: ^4.2.0
+        version: 4.2.0
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
+  packages/o-gateway-registry:
+    dependencies:
+      '@olane/o-config':
+        specifier: 0.9.0
+        version: 0.9.0
+      '@olane/o-core':
+        specifier: 0.9.0
+        version: 0.9.0
+      '@olane/o-gateway-interface':
+        specifier: 0.9.0
+        version: 0.9.0
+      '@olane/o-protocol':
+        specifier: 0.9.0
+        version: 0.9.0
       debug:
         specifier: ^4.4.3
         version: 4.4.3(supports-color@8.1.1)
@@ -773,23 +846,23 @@ importers:
   packages/o-intelligence:
     dependencies:
       '@olane/o-config':
-        specifier: 0.8.20
-        version: link:../o-config
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-core':
-        specifier: 0.8.20
-        version: link:../o-core
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-lane':
-        specifier: 0.8.20
-        version: link:../o-lane
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-node':
-        specifier: 0.8.20
-        version: link:../o-node
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-protocol':
-        specifier: 0.8.20
-        version: link:../o-protocol
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-tool':
-        specifier: 0.8.20
-        version: link:../o-tool
+        specifier: 0.9.0
+        version: 0.9.0
       debug:
         specifier: ^4.4.3
         version: 4.4.3(supports-color@8.1.1)
@@ -855,23 +928,23 @@ importers:
   packages/o-lane:
     dependencies:
       '@olane/o-config':
-        specifier: 0.8.20
-        version: link:../o-config
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-core':
-        specifier: 0.8.20
-        version: link:../o-core
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-node':
-        specifier: 0.8.20
-        version: link:../o-node
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-protocol':
-        specifier: 0.8.20
-        version: link:../o-protocol
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-storage':
-        specifier: 0.8.20
-        version: link:../o-storage
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-tool':
-        specifier: 0.8.20
-        version: link:../o-tool
+        specifier: 0.9.0
+        version: 0.9.0
       debug:
         specifier: ^4.4.3
         version: 4.4.3(supports-color@8.1.1)
@@ -892,8 +965,8 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.2.0(jiti@1.21.7))
       '@olane/o-test':
-        specifier: 0.8.20
-        version: link:../o-test
+        specifier: 0.9.0
+        version: 0.9.0
       '@tsconfig/node20':
         specifier: ^20.1.9
         version: 20.1.9
@@ -952,26 +1025,26 @@ importers:
   packages/o-leader:
     dependencies:
       '@olane/o-config':
-        specifier: 0.8.20
-        version: link:../o-config
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-core':
-        specifier: 0.8.20
-        version: link:../o-core
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-gateway-olane':
-        specifier: 0.8.20
-        version: link:../o-gateway-olane
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-lane':
-        specifier: 0.8.20
-        version: link:../o-lane
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-node':
-        specifier: 0.8.20
-        version: link:../o-node
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-protocol':
-        specifier: 0.8.20
-        version: link:../o-protocol
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-tool':
-        specifier: 0.8.20
-        version: link:../o-tool
+        specifier: 0.9.0
+        version: 0.9.0
       debug:
         specifier: ^4.4.3
         version: 4.4.3(supports-color@8.1.1)
@@ -1034,23 +1107,23 @@ importers:
   packages/o-login:
     dependencies:
       '@olane/o-config':
-        specifier: 0.8.20
-        version: link:../o-config
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-core':
-        specifier: 0.8.20
-        version: link:../o-core
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-lane':
-        specifier: 0.8.20
-        version: link:../o-lane
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-node':
-        specifier: 0.8.20
-        version: link:../o-node
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-protocol':
-        specifier: 0.8.20
-        version: link:../o-protocol
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-tool':
-        specifier: 0.8.20
-        version: link:../o-tool
+        specifier: 0.9.0
+        version: 0.9.0
       debug:
         specifier: ^4.4.3
         version: 4.4.3(supports-color@8.1.1)
@@ -1119,32 +1192,32 @@ importers:
         specifier: ^1.27.1
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       '@olane/o-config':
-        specifier: 0.8.20
-        version: link:../o-config
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-core':
-        specifier: 0.8.20
-        version: link:../o-core
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-intelligence':
-        specifier: 0.8.20
-        version: link:../o-intelligence
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-lane':
-        specifier: 0.8.20
-        version: link:../o-lane
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-leader':
-        specifier: 0.8.20
-        version: link:../o-leader
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-node':
-        specifier: 0.8.20
-        version: link:../o-node
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-protocol':
-        specifier: 0.8.20
-        version: link:../o-protocol
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-storage':
-        specifier: 0.8.20
-        version: link:../o-storage
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-tool':
-        specifier: 0.8.20
-        version: link:../o-tool
+        specifier: 0.9.0
+        version: 0.9.0
       debug:
         specifier: ^4.4.3
         version: 4.4.3(supports-color@8.1.1)
@@ -1225,32 +1298,32 @@ importers:
         specifier: ^5.0.10
         version: 5.0.16
       '@olane/o-config':
-        specifier: 0.8.20
-        version: link:../o-config
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-core':
-        specifier: 0.8.20
-        version: link:../o-core
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-intelligence':
-        specifier: 0.8.20
-        version: link:../o-intelligence
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-lane':
-        specifier: 0.8.20
-        version: link:../o-lane
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-leader':
-        specifier: 0.8.20
-        version: link:../o-leader
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-node':
-        specifier: 0.8.20
-        version: link:../o-node
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-protocol':
-        specifier: 0.8.20
-        version: link:../o-protocol
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-storage':
-        specifier: 0.8.20
-        version: link:../o-storage
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-tool':
-        specifier: 0.8.20
-        version: link:../o-tool
+        specifier: 0.9.0
+        version: 0.9.0
       debug:
         specifier: ^4.4.3
         version: 4.4.3(supports-color@8.1.1)
@@ -1334,17 +1407,17 @@ importers:
   packages/o-node:
     dependencies:
       '@olane/o-config':
-        specifier: 0.8.20
-        version: link:../o-config
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-core':
-        specifier: 0.8.20
-        version: link:../o-core
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-protocol':
-        specifier: 0.8.20
-        version: link:../o-protocol
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-tool':
-        specifier: 0.8.20
-        version: link:../o-tool
+        specifier: 0.9.0
+        version: 0.9.0
       debug:
         specifier: ^4.4.3
         version: 4.4.3(supports-color@8.1.1)
@@ -1365,8 +1438,8 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.2.0(jiti@1.21.7))
       '@olane/o-test':
-        specifier: 0.8.20
-        version: link:../o-test
+        specifier: 0.9.0
+        version: 0.9.0
       '@tsconfig/node20':
         specifier: ^20.1.9
         version: 20.1.9
@@ -1428,47 +1501,47 @@ importers:
         specifier: ^4.1.3
         version: 4.2.0
       '@olane/o-agent':
-        specifier: 0.8.20
-        version: link:../o-agent
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-client-limited':
-        specifier: 0.8.20
-        version: link:../o-client-limited
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-config':
-        specifier: 0.8.20
-        version: link:../o-config
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-core':
-        specifier: 0.8.20
-        version: link:../o-core
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-intelligence':
-        specifier: 0.8.20
-        version: link:../o-intelligence
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-lane':
-        specifier: 0.8.20
-        version: link:../o-lane
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-leader':
-        specifier: 0.8.20
-        version: link:../o-leader
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-login':
-        specifier: 0.8.20
-        version: link:../o-login
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-node':
-        specifier: 0.8.20
-        version: link:../o-node
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-protocol':
-        specifier: 0.8.20
-        version: link:../o-protocol
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-storage':
-        specifier: 0.8.20
-        version: link:../o-storage
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-tool':
-        specifier: 0.8.20
-        version: link:../o-tool
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-tool-registry':
-        specifier: 0.8.20
-        version: link:../o-tool-registry
+        specifier: 0.9.0
+        version: 0.9.0(@browserbasehq/sdk@2.10.0(encoding@0.1.13))(@browserbasehq/stagehand@1.14.0(@playwright/test@1.59.1)(deepmerge@4.3.1)(dotenv@17.4.2)(encoding@0.1.13)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))(zod@4.3.6))(@ibm-cloud/watsonx-ai@1.7.11(typescript@5.9.3))(axios@1.15.0(debug@4.4.3))(cborg@4.5.8)(encoding@0.1.13)(handlebars@4.7.9)(ibm-cloud-sdk-core@5.4.11)(ignore@5.3.2)(interface-datastore@8.3.2)(it-all@3.0.11)(jsonwebtoken@9.0.3)(lodash@4.18.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))(playwright@1.59.1)(puppeteer@22.14.0(typescript@5.9.3))(weaviate-client@3.12.1(encoding@0.1.13))(ws@8.20.0)(zod@4.3.6)
       '@olane/o-tools-common':
-        specifier: 0.8.20
-        version: link:../o-tools-common
+        specifier: 0.9.0
+        version: 0.9.0
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -1552,8 +1625,8 @@ importers:
   packages/o-protocol:
     dependencies:
       '@olane/o-config':
-        specifier: 0.8.20
-        version: link:../o-config
+        specifier: 0.9.0
+        version: 0.9.0
     devDependencies:
       '@tsconfig/node20':
         specifier: ^20.1.9
@@ -1583,8 +1656,8 @@ importers:
   packages/o-server:
     dependencies:
       '@olane/o-core':
-        specifier: 0.8.20
-        version: link:../o-core
+        specifier: 0.9.0
+        version: 0.9.0
       cors:
         specifier: ^2.8.6
         version: 2.8.6
@@ -1683,20 +1756,20 @@ importers:
   packages/o-storage:
     dependencies:
       '@olane/o-config':
-        specifier: 0.8.20
-        version: link:../o-config
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-core':
-        specifier: 0.8.20
-        version: link:../o-core
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-node':
-        specifier: 0.8.20
-        version: link:../o-node
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-protocol':
-        specifier: 0.8.20
-        version: link:../o-protocol
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-tool':
-        specifier: 0.8.20
-        version: link:../o-tool
+        specifier: 0.9.0
+        version: 0.9.0
       debug:
         specifier: ^4.4.3
         version: 4.4.3(supports-color@8.1.1)
@@ -1714,11 +1787,11 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.2.0(jiti@1.21.7))
       '@olane/o-intelligence':
-        specifier: 0.8.20
-        version: link:../o-intelligence
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-leader':
-        specifier: 0.8.20
-        version: link:../o-leader
+        specifier: 0.9.0
+        version: 0.9.0
       '@tsconfig/node20':
         specifier: ^20.1.9
         version: 20.1.9
@@ -1774,20 +1847,20 @@ importers:
   packages/o-test:
     dependencies:
       '@olane/o-core':
-        specifier: 0.8.20
-        version: link:../o-core
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-lane':
-        specifier: 0.8.20
-        version: link:../o-lane
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-node':
-        specifier: 0.8.20
-        version: link:../o-node
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-protocol':
-        specifier: 0.8.20
-        version: link:../o-protocol
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-tool':
-        specifier: 0.8.20
-        version: link:../o-tool
+        specifier: 0.9.0
+        version: 0.9.0
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -1805,8 +1878,8 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.2.0(jiti@1.21.7))
       '@olane/o-leader':
-        specifier: 0.8.20
-        version: link:../o-leader
+        specifier: 0.9.0
+        version: 0.9.0
       '@tsconfig/node20':
         specifier: ^20.1.9
         version: 20.1.9
@@ -1868,14 +1941,14 @@ importers:
   packages/o-tool:
     dependencies:
       '@olane/o-config':
-        specifier: 0.8.20
-        version: link:../o-config
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-core':
-        specifier: 0.8.20
-        version: link:../o-core
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-protocol':
-        specifier: 0.8.20
-        version: link:../o-protocol
+        specifier: 0.9.0
+        version: 0.9.0
       debug:
         specifier: ^4.4.3
         version: 4.4.3(supports-color@8.1.1)
@@ -1951,37 +2024,37 @@ importers:
         version: 3.8.1
       '@langchain/community':
         specifier: 0.3.47
-        version: 0.3.47(@browserbasehq/sdk@2.10.0(encoding@0.1.13))(@browserbasehq/stagehand@1.14.0(@playwright/test@1.59.1)(deepmerge@4.3.1)(dotenv@16.6.1)(encoding@0.1.13)(openai@5.23.2(ws@8.20.0)(zod@3.25.76))(zod@3.25.76))(@huggingface/transformers@3.8.1)(@ibm-cloud/watsonx-ai@1.7.11(typescript@5.9.3))(@langchain/core@0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@3.25.76)))(@opentelemetry/api@1.9.1)(axios@1.15.0(debug@4.4.3))(cborg@4.5.8)(encoding@0.1.13)(handlebars@4.7.9)(ibm-cloud-sdk-core@5.4.11)(ignore@5.3.2)(interface-datastore@8.3.2)(it-all@3.0.11)(jsonwebtoken@9.0.3)(lodash@4.18.1)(openai@5.23.2(ws@8.20.0)(zod@3.25.76))(playwright@1.59.1)(puppeteer@22.14.0(typescript@5.9.3))(weaviate-client@3.12.1(encoding@0.1.13))(ws@8.20.0)
+        version: 0.3.47(@browserbasehq/sdk@2.10.0(encoding@0.1.13))(@browserbasehq/stagehand@1.14.0(@playwright/test@1.59.1)(deepmerge@4.3.1)(dotenv@16.6.1)(encoding@0.1.13)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))(zod@4.3.6))(@huggingface/transformers@3.8.1)(@ibm-cloud/watsonx-ai@1.7.11(typescript@5.9.3))(@langchain/core@0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6)))(@opentelemetry/api@1.9.1)(axios@1.15.0(debug@4.4.3))(cborg@4.5.8)(encoding@0.1.13)(handlebars@4.7.9)(ibm-cloud-sdk-core@5.4.11)(ignore@5.3.2)(interface-datastore@8.3.2)(it-all@3.0.11)(jsonwebtoken@9.0.3)(lodash@4.18.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))(playwright@1.59.1)(puppeteer@22.14.0(typescript@5.9.3))(weaviate-client@3.12.1(encoding@0.1.13))(ws@8.20.0)
       '@langchain/core':
         specifier: 0.3.61
-        version: 0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@3.25.76))
+        version: 0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))
       '@olane/o-config':
-        specifier: 0.8.20
-        version: link:../o-config
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-core':
-        specifier: 0.8.20
-        version: link:../o-core
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-intelligence':
-        specifier: 0.8.20
-        version: link:../o-intelligence
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-lane':
-        specifier: 0.8.20
-        version: link:../o-lane
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-mcp':
-        specifier: 0.8.20
-        version: link:../o-mcp
+        specifier: 0.9.0
+        version: 0.9.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       '@olane/o-node':
-        specifier: 0.8.20
-        version: link:../o-node
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-protocol':
-        specifier: 0.8.20
-        version: link:../o-protocol
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-tool':
-        specifier: 0.8.20
-        version: link:../o-tool
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-tools-common':
-        specifier: 0.8.20
-        version: link:../o-tools-common
+        specifier: 0.9.0
+        version: 0.9.0
       debug:
         specifier: ^4.4.1
         version: 4.4.3(supports-color@8.1.1)
@@ -1990,7 +2063,7 @@ importers:
         version: 16.6.1
       langchain:
         specifier: 0.3.29
-        version: 0.3.29(@langchain/core@0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@3.25.76)))(@opentelemetry/api@1.9.1)(axios@1.15.0(debug@4.4.3))(handlebars@4.7.9)(openai@5.23.2(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)
+        version: 0.3.29(@langchain/core@0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6)))(@opentelemetry/api@1.9.1)(axios@1.15.0(debug@4.4.3))(handlebars@4.7.9)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.3.4
@@ -2053,32 +2126,32 @@ importers:
   packages/o-tools-common:
     dependencies:
       '@olane/o-approval':
-        specifier: 0.8.20
-        version: link:../o-approval
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-config':
-        specifier: 0.8.20
-        version: link:../o-config
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-core':
-        specifier: 0.8.20
-        version: link:../o-core
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-lane':
-        specifier: 0.8.20
-        version: link:../o-lane
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-leader':
-        specifier: 0.8.20
-        version: link:../o-leader
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-node':
-        specifier: 0.8.20
-        version: link:../o-node
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-protocol':
-        specifier: 0.8.20
-        version: link:../o-protocol
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-storage':
-        specifier: 0.8.20
-        version: link:../o-storage
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-tool':
-        specifier: 0.8.20
-        version: link:../o-tool
+        specifier: 0.9.0
+        version: 0.9.0
       debug:
         specifier: ^4.4.3
         version: 4.4.3(supports-color@8.1.1)
@@ -4962,6 +5035,67 @@ packages:
 
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
+
+  '@olane/o-agent@0.9.0':
+    resolution: {integrity: sha512-EjnKHChzkZ40BwSb4xydxFEurX0M/SxUoyGPjHQOXbYbJcTggLjpEsMS+rWxLJ3EEblmKe/lUdIopsAnWC9+TA==}
+
+  '@olane/o-approval@0.9.0':
+    resolution: {integrity: sha512-Eteb1XMjShWRFPPB9tvQF6lQnsujPI3rrK4JybOIGQRx21K9RTrpw8a6pu678sUSsGWCKo5NATB0nTwMTl9DQw==}
+
+  '@olane/o-client-limited@0.9.0':
+    resolution: {integrity: sha512-2NexEB1wrfDQUbd6OWjYjPVWVRMwEUC+btKOlNDpCqUD3oAkt45tB0ZGsw427PMcU6B+aZllPVF0vHWCs55ZAQ==}
+
+  '@olane/o-config@0.9.0':
+    resolution: {integrity: sha512-NFPyBYtSDp2Pzxs4fKMkmC4i9HUGVYXPPTavLky+f2af4nbI5p84QCDEnSoKd7NbBEN3gxFv7muzPhyN6M1v0Q==}
+
+  '@olane/o-context@0.9.0':
+    resolution: {integrity: sha512-Reta44CZ5CA3Y3SGuwTb+bLGsDjx4OZemyOj30sce8EvsNMvq9JVSlJNEOrnKc6rn+msgbZ/S/c9teJxacxRGA==}
+
+  '@olane/o-core@0.9.0':
+    resolution: {integrity: sha512-Y/ynE/O2nEYO3AAKMHbnGx6VNt2Tibu2luNgJVoheuV0Ow1uFuQewfmTtzpvASm0p8NhB+DlPPxHkXGMyTxbrA==}
+
+  '@olane/o-gateway-interface@0.9.0':
+    resolution: {integrity: sha512-HV6Fey9zaJPPeu9mc6UTDO6iK2HbJY3q0ofnqc1Eou/anj6oYuJLEZW4XfLd/kwnjabjDciFyHxIQcL7s0ltFQ==}
+
+  '@olane/o-gateway-olane@0.9.0':
+    resolution: {integrity: sha512-qiODourur/LNl3/2gqzD6ZyM9vpFXKw2OYHLrx0Af4HFNs2POL1pSGwfYxG5oLo85iLjf55zpdMyrG/sx/+ZGQ==}
+
+  '@olane/o-intelligence@0.9.0':
+    resolution: {integrity: sha512-1xBYgMyBSia9tD5rgI55qRcqoMkva6bxHBr5aHTIRg4cIytcB1W8CZtO5rksb77RzzMwBP6iiJxTfaz2J2qnRw==}
+
+  '@olane/o-lane@0.9.0':
+    resolution: {integrity: sha512-5yOqfOWqPnDQK+sVbnhv+OcDAcnAoJljKLRciHsOeTKgUKWWG6jKeXURNWUyLMyo4R8QwAnAaB+4vDUrvi7l4g==}
+
+  '@olane/o-leader@0.9.0':
+    resolution: {integrity: sha512-jjLP2fQ2jHODI3YVRp1IPMkRrkgogp7ZezlhuhDo3pWFp6pEWvUDdHViERhpqR8AqTXocXt0GVnPX55zure0mw==}
+
+  '@olane/o-login@0.9.0':
+    resolution: {integrity: sha512-mzrMX4bYoHmy+oLjUFgOsBdXZclXjFWBpXJ6Y8wh9b6UiUuZQ9ceHxNk2DjWtYiwnBvkdJbMtkcq6eI62oFeyg==}
+
+  '@olane/o-mcp@0.9.0':
+    resolution: {integrity: sha512-UvUQgtPDbu9Bh/Tk3emnclfbDOWddQqAInyc4Grp6jEfiEN6q+gBLS/sdjyVTMg9unREmDtXZgbcE6ATKbTc4Q==}
+
+  '@olane/o-node@0.9.0':
+    resolution: {integrity: sha512-FYuPyhcknaIpj2YdksqFcu08Sw+wdYjNQPZnkVju/lG35kDeH74grpBBo6qdtZxUeAZ+2woEhH+Hf+Huq19HmA==}
+
+  '@olane/o-protocol@0.9.0':
+    resolution: {integrity: sha512-inJ73tMbi6keew9Bhja+gcl/ofwiicpdIyTUEGkr9BZAQwQDc16Z/ZU13rWP7jok8i2ZauBmtWqNinSD+4T1Bg==}
+    engines: {node: '>=20.0.0'}
+
+  '@olane/o-storage@0.9.0':
+    resolution: {integrity: sha512-3KmWIlX8R8mngTgLMqRytaEYAdCL4uL5LSMRmTdgMfQ+vK2sIp1UhTF3Dh8irq1WS2jTLfStMoJR5s9ZzHnZDQ==}
+
+  '@olane/o-test@0.9.0':
+    resolution: {integrity: sha512-EoG/V8gyXJ5mZo/DJTAuGvaPcwd5irEYcJAGImrxw2tQlcHXqxMH81rkb2qpMhUQlstS/8JfkeQui2eOMToawA==}
+
+  '@olane/o-tool-registry@0.9.0':
+    resolution: {integrity: sha512-OVuEdL1QpoIR1sx5/ClCoS9RTM5S2N4bJVqr3jU4+j83QrjdlxmT4FN0oGh/d2fuSg6u0Ex8rCAdWzmAQr13Aw==}
+
+  '@olane/o-tool@0.9.0':
+    resolution: {integrity: sha512-PExoGF9s19nVlfnJuLGe/FO5NG2LuUEzOTFEZZHv4CPRv0GxF8uzb+5gTXgsMzo5u4BVtz9eBeQTuCNM/7o5rw==}
+
+  '@olane/o-tools-common@0.9.0':
+    resolution: {integrity: sha512-RylpfeguVM21L1EzbDtXf6igqfgUF17+wOYHXheFzhFPPKAJrFA+IZ+XjkTNsifFUH9zTpLeysRKwfGuwDT5vw==}
 
   '@openapi-contrib/openapi-schema-to-json-schema@3.2.0':
     resolution: {integrity: sha512-Gj6C0JwCr8arj0sYuslWXUBSP/KnUlEGnPW4qxlXvAl543oaNQgMgIgkQUA6vs5BCCvwTEiL8m/wdWzfl4UvSw==}
@@ -14407,17 +14541,33 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@browserbasehq/stagehand@1.14.0(@playwright/test@1.59.1)(deepmerge@4.3.1)(dotenv@16.6.1)(encoding@0.1.13)(openai@5.23.2(ws@8.20.0)(zod@3.25.76))(zod@3.25.76)':
+  '@browserbasehq/stagehand@1.14.0(@playwright/test@1.59.1)(deepmerge@4.3.1)(dotenv@16.6.1)(encoding@0.1.13)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.27.3(encoding@0.1.13)
       '@browserbasehq/sdk': 2.10.0(encoding@0.1.13)
       '@playwright/test': 1.59.1
       deepmerge: 4.3.1
       dotenv: 16.6.1
-      openai: 5.23.2(ws@8.20.0)(zod@3.25.76)
+      openai: 5.23.2(ws@8.20.0)(zod@4.3.6)
       ws: 8.20.0
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
+
+  '@browserbasehq/stagehand@1.14.0(@playwright/test@1.59.1)(deepmerge@4.3.1)(dotenv@17.4.2)(encoding@0.1.13)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))(zod@4.3.6)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.27.3(encoding@0.1.13)
+      '@browserbasehq/sdk': 2.10.0(encoding@0.1.13)
+      '@playwright/test': 1.59.1
+      deepmerge: 4.3.1
+      dotenv: 17.4.2
+      openai: 5.23.2(ws@8.20.0)(zod@4.3.6)
+      ws: 8.20.0
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -15723,21 +15873,21 @@ snapshots:
 
   '@keyv/serialize@1.1.1': {}
 
-  '@langchain/community@0.3.47(@browserbasehq/sdk@2.10.0(encoding@0.1.13))(@browserbasehq/stagehand@1.14.0(@playwright/test@1.59.1)(deepmerge@4.3.1)(dotenv@16.6.1)(encoding@0.1.13)(openai@5.23.2(ws@8.20.0)(zod@3.25.76))(zod@3.25.76))(@huggingface/transformers@3.8.1)(@ibm-cloud/watsonx-ai@1.7.11(typescript@5.9.3))(@langchain/core@0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@3.25.76)))(@opentelemetry/api@1.9.1)(axios@1.15.0(debug@4.4.3))(cborg@4.5.8)(encoding@0.1.13)(handlebars@4.7.9)(ibm-cloud-sdk-core@5.4.11)(ignore@5.3.2)(interface-datastore@8.3.2)(it-all@3.0.11)(jsonwebtoken@9.0.3)(lodash@4.18.1)(openai@5.23.2(ws@8.20.0)(zod@3.25.76))(playwright@1.59.1)(puppeteer@22.14.0(typescript@5.9.3))(weaviate-client@3.12.1(encoding@0.1.13))(ws@8.20.0)':
+  '@langchain/community@0.3.47(@browserbasehq/sdk@2.10.0(encoding@0.1.13))(@browserbasehq/stagehand@1.14.0(@playwright/test@1.59.1)(deepmerge@4.3.1)(dotenv@16.6.1)(encoding@0.1.13)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))(zod@4.3.6))(@huggingface/transformers@3.8.1)(@ibm-cloud/watsonx-ai@1.7.11(typescript@5.9.3))(@langchain/core@0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6)))(@opentelemetry/api@1.9.1)(axios@1.15.0(debug@4.4.3))(cborg@4.5.8)(encoding@0.1.13)(handlebars@4.7.9)(ibm-cloud-sdk-core@5.4.11)(ignore@5.3.2)(interface-datastore@8.3.2)(it-all@3.0.11)(jsonwebtoken@9.0.3)(lodash@4.18.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))(playwright@1.59.1)(puppeteer@22.14.0(typescript@5.9.3))(weaviate-client@3.12.1(encoding@0.1.13))(ws@8.20.0)':
     dependencies:
-      '@browserbasehq/stagehand': 1.14.0(@playwright/test@1.59.1)(deepmerge@4.3.1)(dotenv@16.6.1)(encoding@0.1.13)(openai@5.23.2(ws@8.20.0)(zod@3.25.76))(zod@3.25.76)
+      '@browserbasehq/stagehand': 1.14.0(@playwright/test@1.59.1)(deepmerge@4.3.1)(dotenv@16.6.1)(encoding@0.1.13)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))(zod@4.3.6)
       '@ibm-cloud/watsonx-ai': 1.7.11(typescript@5.9.3)
-      '@langchain/core': 0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@3.25.76))
-      '@langchain/openai': 0.5.18(@langchain/core@0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@3.25.76)))(ws@8.20.0)
-      '@langchain/weaviate': 0.2.3(@langchain/core@0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@3.25.76)))(encoding@0.1.13)
+      '@langchain/core': 0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))
+      '@langchain/openai': 0.5.18(@langchain/core@0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6)))(ws@8.20.0)
+      '@langchain/weaviate': 0.2.3(@langchain/core@0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6)))(encoding@0.1.13)
       binary-extensions: 2.3.0
       expr-eval: 2.0.2
       flat: 5.0.2
       ibm-cloud-sdk-core: 5.4.11
       js-yaml: 4.1.1
-      langchain: 0.3.29(@langchain/core@0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@3.25.76)))(@opentelemetry/api@1.9.1)(axios@1.15.0(debug@4.4.3))(handlebars@4.7.9)(openai@5.23.2(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)
-      langsmith: 0.3.87(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@3.25.76))
-      openai: 5.23.2(ws@8.20.0)(zod@3.25.76)
+      langchain: 0.3.29(@langchain/core@0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6)))(@opentelemetry/api@1.9.1)(axios@1.15.0(debug@4.4.3))(handlebars@4.7.9)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      langsmith: 0.3.87(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))
+      openai: 5.23.2(ws@8.20.0)(zod@4.3.6)
       uuid: 10.0.0
       zod: 3.25.76
     optionalDependencies:
@@ -15774,14 +15924,65 @@ snapshots:
       - handlebars
       - peggy
 
-  '@langchain/core@0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@3.25.76))':
+  '@langchain/community@0.3.47(@browserbasehq/sdk@2.10.0(encoding@0.1.13))(@browserbasehq/stagehand@1.14.0(@playwright/test@1.59.1)(deepmerge@4.3.1)(dotenv@17.4.2)(encoding@0.1.13)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))(zod@4.3.6))(@huggingface/transformers@3.8.1)(@ibm-cloud/watsonx-ai@1.7.11(typescript@5.9.3))(@langchain/core@0.3.61(openai@5.23.2(ws@8.20.0)(zod@4.3.6)))(axios@1.15.0(debug@4.4.3))(cborg@4.5.8)(encoding@0.1.13)(handlebars@4.7.9)(ibm-cloud-sdk-core@5.4.11)(ignore@5.3.2)(interface-datastore@8.3.2)(it-all@3.0.11)(jsonwebtoken@9.0.3)(lodash@4.18.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))(playwright@1.59.1)(puppeteer@22.14.0(typescript@5.9.3))(weaviate-client@3.12.1(encoding@0.1.13))(ws@8.20.0)':
+    dependencies:
+      '@browserbasehq/stagehand': 1.14.0(@playwright/test@1.59.1)(deepmerge@4.3.1)(dotenv@17.4.2)(encoding@0.1.13)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))(zod@4.3.6)
+      '@ibm-cloud/watsonx-ai': 1.7.11(typescript@5.9.3)
+      '@langchain/core': 0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))
+      '@langchain/openai': 0.5.18(@langchain/core@0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6)))(ws@8.20.0)
+      '@langchain/weaviate': 0.2.3(@langchain/core@0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6)))(encoding@0.1.13)
+      binary-extensions: 2.3.0
+      expr-eval: 2.0.2
+      flat: 5.0.2
+      ibm-cloud-sdk-core: 5.4.11
+      js-yaml: 4.1.1
+      langchain: 0.3.29(@langchain/core@0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6)))(@opentelemetry/api@1.9.1)(axios@1.15.0(debug@4.4.3))(handlebars@4.7.9)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      langsmith: 0.3.87(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))
+      openai: 5.23.2(ws@8.20.0)(zod@4.3.6)
+      uuid: 10.0.0
+      zod: 3.25.76
+    optionalDependencies:
+      '@browserbasehq/sdk': 2.10.0(encoding@0.1.13)
+      '@huggingface/transformers': 3.8.1
+      cborg: 4.5.8
+      ignore: 5.3.2
+      interface-datastore: 8.3.2
+      it-all: 3.0.11
+      jsonwebtoken: 9.0.3
+      lodash: 4.18.1
+      playwright: 1.59.1
+      puppeteer: 22.14.0(typescript@5.9.3)
+      weaviate-client: 3.12.1(encoding@0.1.13)
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - '@langchain/anthropic'
+      - '@langchain/aws'
+      - '@langchain/cerebras'
+      - '@langchain/cohere'
+      - '@langchain/deepseek'
+      - '@langchain/google-genai'
+      - '@langchain/google-vertexai'
+      - '@langchain/google-vertexai-web'
+      - '@langchain/groq'
+      - '@langchain/mistralai'
+      - '@langchain/ollama'
+      - '@langchain/xai'
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - axios
+      - encoding
+      - handlebars
+      - peggy
+
+  '@langchain/core@0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.21
-      langsmith: 0.3.87(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@3.25.76))
+      langsmith: 0.3.87(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -15794,23 +15995,23 @@ snapshots:
       - '@opentelemetry/sdk-trace-base'
       - openai
 
-  '@langchain/openai@0.5.18(@langchain/core@0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@3.25.76)))(ws@8.20.0)':
+  '@langchain/openai@0.5.18(@langchain/core@0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6)))(ws@8.20.0)':
     dependencies:
-      '@langchain/core': 0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@3.25.76))
+      '@langchain/core': 0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))
       js-tiktoken: 1.0.21
       openai: 5.23.2(ws@8.20.0)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - ws
 
-  '@langchain/textsplitters@0.1.0(@langchain/core@0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@3.25.76)))':
+  '@langchain/textsplitters@0.1.0(@langchain/core@0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6)))':
     dependencies:
-      '@langchain/core': 0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@3.25.76))
+      '@langchain/core': 0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))
       js-tiktoken: 1.0.21
 
-  '@langchain/weaviate@0.2.3(@langchain/core@0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@3.25.76)))(encoding@0.1.13)':
+  '@langchain/weaviate@0.2.3(@langchain/core@0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6)))(encoding@0.1.13)':
     dependencies:
-      '@langchain/core': 0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@3.25.76))
+      '@langchain/core': 0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))
       uuid: 10.0.0
       weaviate-client: 3.12.1(encoding@0.1.13)
     transitivePeerDependencies:
@@ -17095,6 +17296,463 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
+  '@olane/o-agent@0.9.0':
+    dependencies:
+      '@olane/o-core': 0.9.0
+      '@olane/o-lane': 0.9.0
+      '@olane/o-node': 0.9.0
+      '@olane/o-protocol': 0.9.0
+      '@olane/o-tool': 0.9.0
+      debug: 4.4.3(supports-color@8.1.1)
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@olane/o-approval@0.9.0':
+    dependencies:
+      '@olane/o-config': 0.9.0
+      '@olane/o-core': 0.9.0
+      '@olane/o-lane': 0.9.0
+      '@olane/o-node': 0.9.0
+      '@olane/o-protocol': 0.9.0
+      '@olane/o-tool': 0.9.0
+      debug: 4.4.3(supports-color@8.1.1)
+      dotenv: 17.4.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@olane/o-client-limited@0.9.0':
+    dependencies:
+      '@olane/o-config': 0.9.0
+      '@olane/o-core': 0.9.0
+      '@olane/o-node': 0.9.0
+      '@olane/o-protocol': 0.9.0
+      '@olane/o-tool': 0.9.0
+      debug: 4.4.3(supports-color@8.1.1)
+      dotenv: 17.4.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@olane/o-config@0.9.0':
+    dependencies:
+      '@chainsafe/libp2p-noise': 17.0.0
+      '@chainsafe/libp2p-yamux': 8.0.1
+      '@libp2p/bootstrap': 12.0.16
+      '@libp2p/crypto': 5.1.15
+      '@libp2p/identify': 4.1.0
+      '@libp2p/interface': 3.2.0
+      '@libp2p/kad-dht': 16.2.0
+      '@libp2p/memory': 2.0.15
+      '@libp2p/peer-id-factory': 4.2.4
+      '@libp2p/peer-store': 12.0.15
+      '@libp2p/ping': 3.1.0
+      '@libp2p/pubsub': 10.1.18
+      '@libp2p/tcp': 11.0.15
+      '@libp2p/utils': 7.0.15
+      '@libp2p/websockets': 10.1.8
+      '@libp2p/webtransport': 6.0.17
+      '@multiformats/multiaddr': 13.0.1
+      it-all: 3.0.11
+      it-pair: 2.0.6
+      it-pipe: 3.0.1
+      it-pushable: 3.2.3
+      libp2p: 3.2.0
+      uint8arraylist: 2.4.9
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@olane/o-context@0.9.0': {}
+
+  '@olane/o-core@0.9.0':
+    dependencies:
+      '@olane/o-config': 0.9.0
+      '@olane/o-context': 0.9.0
+      '@olane/o-protocol': 0.9.0
+      chalk: 5.6.2
+      debug: 4.4.3(supports-color@8.1.1)
+      dotenv: 17.4.2
+      multiformats: 13.4.2
+      stream-json: 1.9.1
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@olane/o-gateway-interface@0.9.0':
+    dependencies:
+      '@olane/o-config': 0.9.0
+      '@olane/o-core': 0.9.0
+      '@olane/o-protocol': 0.9.0
+      '@olane/o-tool': 0.9.0
+      debug: 4.4.3(supports-color@8.1.1)
+      dotenv: 17.4.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@olane/o-gateway-olane@0.9.0':
+    dependencies:
+      '@olane/o-config': 0.9.0
+      '@olane/o-core': 0.9.0
+      '@olane/o-node': 0.9.0
+      '@olane/o-protocol': 0.9.0
+      '@olane/o-tool': 0.9.0
+      debug: 4.4.3(supports-color@8.1.1)
+      dotenv: 17.4.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@olane/o-intelligence@0.9.0':
+    dependencies:
+      '@olane/o-config': 0.9.0
+      '@olane/o-core': 0.9.0
+      '@olane/o-lane': 0.9.0
+      '@olane/o-node': 0.9.0
+      '@olane/o-protocol': 0.9.0
+      '@olane/o-tool': 0.9.0
+      debug: 4.4.3(supports-color@8.1.1)
+      dotenv: 17.4.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@olane/o-lane@0.9.0':
+    dependencies:
+      '@olane/o-config': 0.9.0
+      '@olane/o-core': 0.9.0
+      '@olane/o-node': 0.9.0
+      '@olane/o-protocol': 0.9.0
+      '@olane/o-storage': 0.9.0
+      '@olane/o-tool': 0.9.0
+      debug: 4.4.3(supports-color@8.1.1)
+      dotenv: 17.4.2
+      handlebars: 4.7.9
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@olane/o-leader@0.9.0':
+    dependencies:
+      '@olane/o-config': 0.9.0
+      '@olane/o-core': 0.9.0
+      '@olane/o-gateway-olane': 0.9.0
+      '@olane/o-lane': 0.9.0
+      '@olane/o-node': 0.9.0
+      '@olane/o-protocol': 0.9.0
+      '@olane/o-tool': 0.9.0
+      debug: 4.4.3(supports-color@8.1.1)
+      dotenv: 17.4.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@olane/o-login@0.9.0':
+    dependencies:
+      '@olane/o-config': 0.9.0
+      '@olane/o-core': 0.9.0
+      '@olane/o-lane': 0.9.0
+      '@olane/o-node': 0.9.0
+      '@olane/o-protocol': 0.9.0
+      '@olane/o-tool': 0.9.0
+      debug: 4.4.3(supports-color@8.1.1)
+      dotenv: 17.4.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@olane/o-mcp@0.9.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      '@olane/o-config': 0.9.0
+      '@olane/o-core': 0.9.0
+      '@olane/o-intelligence': 0.9.0
+      '@olane/o-lane': 0.9.0
+      '@olane/o-leader': 0.9.0
+      '@olane/o-node': 0.9.0
+      '@olane/o-protocol': 0.9.0
+      '@olane/o-storage': 0.9.0
+      '@olane/o-tool': 0.9.0
+      debug: 4.4.3(supports-color@8.1.1)
+      dotenv: 17.4.2
+      express: 5.2.1
+      open: 11.0.0
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - zod
+
+  '@olane/o-node@0.9.0':
+    dependencies:
+      '@olane/o-config': 0.9.0
+      '@olane/o-core': 0.9.0
+      '@olane/o-protocol': 0.9.0
+      '@olane/o-tool': 0.9.0
+      debug: 4.4.3(supports-color@8.1.1)
+      dotenv: 17.4.2
+      json5: 2.2.3
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@olane/o-protocol@0.9.0':
+    dependencies:
+      '@olane/o-config': 0.9.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@olane/o-storage@0.9.0':
+    dependencies:
+      '@olane/o-config': 0.9.0
+      '@olane/o-core': 0.9.0
+      '@olane/o-node': 0.9.0
+      '@olane/o-protocol': 0.9.0
+      '@olane/o-tool': 0.9.0
+      debug: 4.4.3(supports-color@8.1.1)
+      dotenv: 17.4.2
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@olane/o-test@0.9.0':
+    dependencies:
+      '@olane/o-core': 0.9.0
+      '@olane/o-lane': 0.9.0
+      '@olane/o-node': 0.9.0
+      '@olane/o-protocol': 0.9.0
+      '@olane/o-tool': 0.9.0
+      chalk: 5.6.2
+      debug: 4.4.3(supports-color@8.1.1)
+      dotenv: 17.4.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@olane/o-tool-registry@0.9.0(@browserbasehq/sdk@2.10.0(encoding@0.1.13))(@browserbasehq/stagehand@1.14.0(@playwright/test@1.59.1)(deepmerge@4.3.1)(dotenv@17.4.2)(encoding@0.1.13)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))(zod@4.3.6))(@ibm-cloud/watsonx-ai@1.7.11(typescript@5.9.3))(axios@1.15.0(debug@4.4.3))(cborg@4.5.8)(encoding@0.1.13)(handlebars@4.7.9)(ibm-cloud-sdk-core@5.4.11)(ignore@5.3.2)(interface-datastore@8.3.2)(it-all@3.0.11)(jsonwebtoken@9.0.3)(lodash@4.18.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))(playwright@1.59.1)(puppeteer@22.14.0(typescript@5.9.3))(weaviate-client@3.12.1(encoding@0.1.13))(ws@8.20.0)(zod@4.3.6)':
+    dependencies:
+      '@huggingface/transformers': 3.8.1
+      '@langchain/community': 0.3.47(@browserbasehq/sdk@2.10.0(encoding@0.1.13))(@browserbasehq/stagehand@1.14.0(@playwright/test@1.59.1)(deepmerge@4.3.1)(dotenv@17.4.2)(encoding@0.1.13)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))(zod@4.3.6))(@huggingface/transformers@3.8.1)(@ibm-cloud/watsonx-ai@1.7.11(typescript@5.9.3))(@langchain/core@0.3.61(openai@5.23.2(ws@8.20.0)(zod@4.3.6)))(axios@1.15.0(debug@4.4.3))(cborg@4.5.8)(encoding@0.1.13)(handlebars@4.7.9)(ibm-cloud-sdk-core@5.4.11)(ignore@5.3.2)(interface-datastore@8.3.2)(it-all@3.0.11)(jsonwebtoken@9.0.3)(lodash@4.18.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))(playwright@1.59.1)(puppeteer@22.14.0(typescript@5.9.3))(weaviate-client@3.12.1(encoding@0.1.13))(ws@8.20.0)
+      '@langchain/core': 0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))
+      '@olane/o-config': 0.9.0
+      '@olane/o-core': 0.9.0
+      '@olane/o-intelligence': 0.9.0
+      '@olane/o-lane': 0.9.0
+      '@olane/o-mcp': 0.9.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      '@olane/o-node': 0.9.0
+      '@olane/o-protocol': 0.9.0
+      '@olane/o-tool': 0.9.0
+      '@olane/o-tools-common': 0.9.0
+      debug: 4.4.3(supports-color@8.1.1)
+      dotenv: 16.6.1
+      langchain: 0.3.29(@langchain/core@0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6)))(@opentelemetry/api@1.9.1)(axios@1.15.0(debug@4.4.3))(handlebars@4.7.9)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+    transitivePeerDependencies:
+      - '@arcjet/redact'
+      - '@aws-crypto/sha256-js'
+      - '@aws-sdk/client-bedrock-agent-runtime'
+      - '@aws-sdk/client-bedrock-runtime'
+      - '@aws-sdk/client-dynamodb'
+      - '@aws-sdk/client-kendra'
+      - '@aws-sdk/client-lambda'
+      - '@aws-sdk/client-s3'
+      - '@aws-sdk/client-sagemaker-runtime'
+      - '@aws-sdk/client-sfn'
+      - '@aws-sdk/credential-provider-node'
+      - '@aws-sdk/dsql-signer'
+      - '@azure/search-documents'
+      - '@azure/storage-blob'
+      - '@browserbasehq/sdk'
+      - '@browserbasehq/stagehand'
+      - '@cfworker/json-schema'
+      - '@clickhouse/client'
+      - '@cloudflare/ai'
+      - '@datastax/astra-db-ts'
+      - '@elastic/elasticsearch'
+      - '@getmetal/metal-sdk'
+      - '@getzep/zep-cloud'
+      - '@getzep/zep-js'
+      - '@gomomento/sdk'
+      - '@gomomento/sdk-core'
+      - '@google-ai/generativelanguage'
+      - '@google-cloud/storage'
+      - '@gradientai/nodejs-sdk'
+      - '@huggingface/inference'
+      - '@ibm-cloud/watsonx-ai'
+      - '@lancedb/lancedb'
+      - '@langchain/anthropic'
+      - '@langchain/aws'
+      - '@langchain/cerebras'
+      - '@langchain/cohere'
+      - '@langchain/deepseek'
+      - '@langchain/google-genai'
+      - '@langchain/google-vertexai'
+      - '@langchain/google-vertexai-web'
+      - '@langchain/groq'
+      - '@langchain/mistralai'
+      - '@langchain/ollama'
+      - '@langchain/xai'
+      - '@layerup/layerup-security'
+      - '@libsql/client'
+      - '@mendable/firecrawl-js'
+      - '@mlc-ai/web-llm'
+      - '@mozilla/readability'
+      - '@neondatabase/serverless'
+      - '@notionhq/client'
+      - '@opensearch-project/opensearch'
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - '@pinecone-database/pinecone'
+      - '@planetscale/database'
+      - '@premai/prem-sdk'
+      - '@qdrant/js-client-rest'
+      - '@raycast/api'
+      - '@rockset/client'
+      - '@smithy/eventstream-codec'
+      - '@smithy/protocol-http'
+      - '@smithy/signature-v4'
+      - '@smithy/util-utf8'
+      - '@spider-cloud/spider-client'
+      - '@supabase/supabase-js'
+      - '@tensorflow-models/universal-sentence-encoder'
+      - '@tensorflow/tfjs-converter'
+      - '@tensorflow/tfjs-core'
+      - '@upstash/ratelimit'
+      - '@upstash/redis'
+      - '@upstash/vector'
+      - '@vercel/kv'
+      - '@vercel/postgres'
+      - '@writerai/writer-sdk'
+      - '@xata.io/client'
+      - '@zilliz/milvus2-sdk-node'
+      - apify-client
+      - assemblyai
+      - axios
+      - azion
+      - better-sqlite3
+      - bufferutil
+      - cassandra-driver
+      - cborg
+      - cheerio
+      - chromadb
+      - closevector-common
+      - closevector-node
+      - closevector-web
+      - cohere-ai
+      - convex
+      - crypto-js
+      - d3-dsv
+      - discord.js
+      - dria
+      - duck-duck-scrape
+      - encoding
+      - epub2
+      - fast-xml-parser
+      - firebase-admin
+      - google-auth-library
+      - googleapis
+      - handlebars
+      - hnswlib-node
+      - html-to-text
+      - ibm-cloud-sdk-core
+      - ignore
+      - interface-datastore
+      - ioredis
+      - it-all
+      - jsdom
+      - jsonwebtoken
+      - llmonitor
+      - lodash
+      - lunary
+      - mammoth
+      - mariadb
+      - mem0ai
+      - mongodb
+      - mysql2
+      - neo4j-driver
+      - notion-to-md
+      - officeparser
+      - openai
+      - pdf-parse
+      - peggy
+      - pg
+      - pg-copy-streams
+      - pickleparser
+      - playwright
+      - portkey-ai
+      - puppeteer
+      - pyodide
+      - redis
+      - replicate
+      - sonix-speech-recognition
+      - srt-parser-2
+      - supports-color
+      - typeorm
+      - typesense
+      - usearch
+      - utf-8-validate
+      - voy-search
+      - weaviate-client
+      - web-auth-library
+      - word-extractor
+      - ws
+      - youtubei.js
+      - zod
+
+  '@olane/o-tool@0.9.0':
+    dependencies:
+      '@olane/o-config': 0.9.0
+      '@olane/o-core': 0.9.0
+      '@olane/o-protocol': 0.9.0
+      debug: 4.4.3(supports-color@8.1.1)
+      dotenv: 17.4.2
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@olane/o-tools-common@0.9.0':
+    dependencies:
+      '@olane/o-approval': 0.9.0
+      '@olane/o-config': 0.9.0
+      '@olane/o-core': 0.9.0
+      '@olane/o-lane': 0.9.0
+      '@olane/o-leader': 0.9.0
+      '@olane/o-node': 0.9.0
+      '@olane/o-protocol': 0.9.0
+      '@olane/o-storage': 0.9.0
+      '@olane/o-tool': 0.9.0
+      debug: 4.4.3(supports-color@8.1.1)
+      dotenv: 17.4.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@openapi-contrib/openapi-schema-to-json-schema@3.2.0':
     dependencies:
       fast-deep-equal: 3.1.3
@@ -17368,7 +18026,7 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
-  '@semantic-release/changelog@6.0.3(semantic-release@25.0.3(typescript@5.9.3))':
+  '@semantic-release/changelog@6.0.3(semantic-release@25.0.3(typescript@5.8.3))':
     dependencies:
       '@semantic-release/error': 3.0.0
       aggregate-error: 3.1.0
@@ -17394,7 +18052,7 @@ snapshots:
 
   '@semantic-release/error@4.0.0': {}
 
-  '@semantic-release/git@10.0.1(semantic-release@25.0.3(typescript@5.9.3))':
+  '@semantic-release/git@10.0.1(semantic-release@25.0.3(typescript@5.8.3))':
     dependencies:
       '@semantic-release/error': 3.0.0
       aggregate-error: 3.1.0
@@ -18058,10 +18716,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.58.2(eslint@10.2.0(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.58.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.58.2
       '@typescript-eslint/type-utils': 8.58.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.8.3)
       '@typescript-eslint/utils': 8.58.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.8.3)
@@ -18515,9 +19173,9 @@ snapshots:
     dependencies:
       '@electron/get': 4.0.3
       '@polka/send-type': 0.5.2
-      '@semantic-release/changelog': 6.0.3(semantic-release@25.0.3(typescript@5.9.3))
+      '@semantic-release/changelog': 6.0.3(semantic-release@25.0.3(typescript@5.8.3))
       '@semantic-release/commit-analyzer': 13.0.1(semantic-release@25.0.3(typescript@5.9.3))
-      '@semantic-release/git': 10.0.1(semantic-release@25.0.3(typescript@5.9.3))
+      '@semantic-release/git': 10.0.1(semantic-release@25.0.3(typescript@5.8.3))
       '@semantic-release/github': 12.0.6(semantic-release@25.0.3(typescript@5.9.3))
       '@semantic-release/npm': 13.1.5(semantic-release@25.0.3(typescript@5.9.3))
       '@semantic-release/release-notes-generator': 14.1.0(semantic-release@25.0.3(typescript@5.9.3))
@@ -18547,7 +19205,7 @@ snapshots:
       esbuild: 0.28.0
       eslint: 9.39.4(jiti@1.21.7)
       eslint-formatter-unix: 9.0.1
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@1.21.7))(typescript@5.9.3))(eslint@10.2.0(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))
       eslint-plugin-jsdoc: 62.9.0(eslint@9.39.4(jiti@1.21.7))
       eslint-plugin-no-only-tests: 3.3.0
       execa: 9.6.1
@@ -18574,7 +19232,7 @@ snapshots:
       micromark-extension-gfm-table: 2.1.1
       micromark-extension-gfm-task-list-item: 2.1.0
       mocha: 11.7.5
-      neostandard: 0.12.2(@typescript-eslint/utils@8.58.2(eslint@10.2.0(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))(typescript@5.8.3)
+      neostandard: 0.12.2(@typescript-eslint/utils@8.58.2(eslint@10.2.0(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))(typescript@5.8.3)
       npm-package-json-lint: 10.2.1(typescript@5.8.3)
       nyc: 18.0.0
       p-map: 7.0.4
@@ -18590,7 +19248,7 @@ snapshots:
       read-pkg-up: 11.0.0
       rimraf: 6.1.3
       semantic-release: 25.0.3(typescript@5.8.3)
-      semantic-release-monorepo: 8.0.2(semantic-release@25.0.3(typescript@5.9.3))
+      semantic-release-monorepo: 8.0.2(semantic-release@25.0.3(typescript@5.8.3))
       semver: 7.7.4
       source-map-support: 0.5.21
       strip-bom: 5.0.0
@@ -18598,9 +19256,9 @@ snapshots:
       strong-log-transformer: 2.1.0
       tempy: 3.2.0
       typedoc: 0.28.19(typescript@5.8.3)
-      typedoc-plugin-mdn-links: 5.1.1(typedoc@0.28.19(typescript@5.8.3))
-      typedoc-plugin-mermaid: 1.12.0(typedoc@0.28.19(typescript@5.8.3))
-      typedoc-plugin-missing-exports: 4.1.3(typedoc@0.28.19(typescript@5.8.3))
+      typedoc-plugin-mdn-links: 5.1.1(typedoc@0.28.19(typescript@5.9.3))
+      typedoc-plugin-mermaid: 1.12.0(typedoc@0.28.19(typescript@5.9.3))
+      typedoc-plugin-missing-exports: 4.1.3(typedoc@0.28.19(typescript@5.9.3))
       typescript: 5.8.3
       typescript-docs-verifier: 3.0.2(typescript@5.8.3)
       wherearewe: 2.0.1
@@ -18622,9 +19280,9 @@ snapshots:
     dependencies:
       '@electron/get': 4.0.3
       '@polka/send-type': 0.5.2
-      '@semantic-release/changelog': 6.0.3(semantic-release@25.0.3(typescript@5.9.3))
+      '@semantic-release/changelog': 6.0.3(semantic-release@25.0.3(typescript@5.8.3))
       '@semantic-release/commit-analyzer': 13.0.1(semantic-release@25.0.3(typescript@5.9.3))
-      '@semantic-release/git': 10.0.1(semantic-release@25.0.3(typescript@5.9.3))
+      '@semantic-release/git': 10.0.1(semantic-release@25.0.3(typescript@5.8.3))
       '@semantic-release/github': 12.0.6(semantic-release@25.0.3(typescript@5.9.3))
       '@semantic-release/npm': 13.1.5(semantic-release@25.0.3(typescript@5.9.3))
       '@semantic-release/release-notes-generator': 14.1.0(semantic-release@25.0.3(typescript@5.9.3))
@@ -18697,7 +19355,7 @@ snapshots:
       read-pkg-up: 11.0.0
       rimraf: 6.1.3
       semantic-release: 25.0.3(typescript@5.8.3)
-      semantic-release-monorepo: 8.0.2(semantic-release@25.0.3(typescript@5.9.3))
+      semantic-release-monorepo: 8.0.2(semantic-release@25.0.3(typescript@5.8.3))
       semver: 7.7.4
       source-map-support: 0.5.21
       strip-bom: 5.0.0
@@ -18705,9 +19363,9 @@ snapshots:
       strong-log-transformer: 2.1.0
       tempy: 3.2.0
       typedoc: 0.28.19(typescript@5.8.3)
-      typedoc-plugin-mdn-links: 5.1.1(typedoc@0.28.19(typescript@5.8.3))
-      typedoc-plugin-mermaid: 1.12.0(typedoc@0.28.19(typescript@5.8.3))
-      typedoc-plugin-missing-exports: 4.1.3(typedoc@0.28.19(typescript@5.8.3))
+      typedoc-plugin-mdn-links: 5.1.1(typedoc@0.28.19(typescript@5.9.3))
+      typedoc-plugin-mermaid: 1.12.0(typedoc@0.28.19(typescript@5.9.3))
+      typedoc-plugin-missing-exports: 4.1.3(typedoc@0.28.19(typescript@5.9.3))
       typescript: 5.8.3
       typescript-docs-verifier: 3.0.2(typescript@5.8.3)
       wherearewe: 2.0.1
@@ -20660,22 +21318,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.58.2(eslint@10.2.0(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.4(jiti@1.21.7)
-      get-tsconfig: 4.14.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.16
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@1.21.7))(typescript@5.9.3))(eslint@10.2.0(jiti@1.21.7))
-      eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.58.2(eslint@10.2.0(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@10.2.0(jiti@1.21.7))
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.58.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -20719,13 +21361,13 @@ snapshots:
       eslint: 9.39.4(jiti@1.21.7)
       eslint-compat-utils: 0.5.1(eslint@9.39.4(jiti@1.21.7))
 
-  eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.58.2(eslint@10.2.0(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@10.2.0(jiti@1.21.7)):
+  eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.58.2(eslint@10.2.0(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
       '@package-json/types': 0.0.12
       '@typescript-eslint/types': 8.58.2
       comment-parser: 1.4.6
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 10.2.0(jiti@1.21.7)
+      eslint: 9.39.4(jiti@1.21.7)
       eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
       is-glob: 4.0.3
       minimatch: 10.2.5
@@ -20757,7 +21399,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@1.21.7))(typescript@5.9.3))(eslint@10.2.0(jiti@1.21.7)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -20766,7 +21408,7 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 10.2.0(jiti@1.21.7)
+      eslint: 9.39.4(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.10
       eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7))
       hasown: 2.0.2
@@ -23370,15 +24012,15 @@ snapshots:
 
   ky@1.14.3: {}
 
-  langchain@0.3.29(@langchain/core@0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@3.25.76)))(@opentelemetry/api@1.9.1)(axios@1.15.0(debug@4.4.3))(handlebars@4.7.9)(openai@5.23.2(ws@8.20.0)(zod@3.25.76))(ws@8.20.0):
+  langchain@0.3.29(@langchain/core@0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6)))(@opentelemetry/api@1.9.1)(axios@1.15.0(debug@4.4.3))(handlebars@4.7.9)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))(ws@8.20.0):
     dependencies:
-      '@langchain/core': 0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@3.25.76))
-      '@langchain/openai': 0.5.18(@langchain/core@0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@3.25.76)))(ws@8.20.0)
-      '@langchain/textsplitters': 0.1.0(@langchain/core@0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@3.25.76)))
+      '@langchain/core': 0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))
+      '@langchain/openai': 0.5.18(@langchain/core@0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6)))(ws@8.20.0)
+      '@langchain/textsplitters': 0.1.0(@langchain/core@0.3.61(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6)))
       js-tiktoken: 1.0.21
       js-yaml: 4.1.1
       jsonpointer: 5.0.1
-      langsmith: 0.3.87(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@3.25.76))
+      langsmith: 0.3.87(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6))
       openapi-types: 12.1.3
       p-retry: 4.6.2
       uuid: 10.0.0
@@ -23394,7 +24036,7 @@ snapshots:
       - openai
       - ws
 
-  langsmith@0.3.87(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@3.25.76)):
+  langsmith@0.3.87(@opentelemetry/api@1.9.1)(openai@5.23.2(ws@8.20.0)(zod@4.3.6)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -23404,7 +24046,7 @@ snapshots:
       uuid: 10.0.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
-      openai: 5.23.2(ws@8.20.0)(zod@3.25.76)
+      openai: 5.23.2(ws@8.20.0)(zod@4.3.6)
 
   latest-version@9.0.0:
     dependencies:
@@ -24663,13 +25305,13 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  neostandard@0.12.2(@typescript-eslint/utils@8.58.2(eslint@10.2.0(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))(typescript@5.8.3):
+  neostandard@0.12.2(@typescript-eslint/utils@8.58.2(eslint@10.2.0(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))(typescript@5.8.3):
     dependencies:
       '@humanwhocodes/gitignore-to-minimatch': 1.0.2
       '@stylistic/eslint-plugin': 2.11.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.8.3)
       eslint: 9.39.4(jiti@1.21.7)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.58.2(eslint@10.2.0(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))
-      eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.58.2(eslint@10.2.0(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@10.2.0(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.58.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.58.2(eslint@10.2.0(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7))
       eslint-plugin-n: 17.24.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.8.3)
       eslint-plugin-promise: 7.2.1(eslint@9.39.4(jiti@1.21.7))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@1.21.7))
@@ -25175,6 +25817,11 @@ snapshots:
     optionalDependencies:
       ws: 8.20.0
       zod: 3.25.76
+
+  openai@5.23.2(ws@8.20.0)(zod@4.3.6):
+    optionalDependencies:
+      ws: 8.20.0
+      zod: 4.3.6
 
   openapi-types@12.1.3: {}
 
@@ -26617,7 +27264,7 @@ snapshots:
       ajv-formats: 2.1.1(ajv@8.18.0)
       ajv-keywords: 5.1.0(ajv@8.18.0)
 
-  semantic-release-monorepo@8.0.2(semantic-release@25.0.3(typescript@5.9.3)):
+  semantic-release-monorepo@8.0.2(semantic-release@25.0.3(typescript@5.8.3)):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       execa: 5.1.1
@@ -26631,12 +27278,12 @@ snapshots:
       ramda: 0.27.2
       read-pkg: 5.2.0
       semantic-release: 25.0.3(typescript@5.8.3)
-      semantic-release-plugin-decorators: 4.0.0(semantic-release@25.0.3(typescript@5.9.3))
+      semantic-release-plugin-decorators: 4.0.0(semantic-release@25.0.3(typescript@5.8.3))
       tempy: 1.0.1
     transitivePeerDependencies:
       - supports-color
 
-  semantic-release-plugin-decorators@4.0.0(semantic-release@25.0.3(typescript@5.9.3)):
+  semantic-release-plugin-decorators@4.0.0(semantic-release@25.0.3(typescript@5.8.3)):
     dependencies:
       semantic-release: 25.0.3(typescript@5.8.3)
 
@@ -27904,16 +28551,16 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typedoc-plugin-mdn-links@5.1.1(typedoc@0.28.19(typescript@5.8.3)):
+  typedoc-plugin-mdn-links@5.1.1(typedoc@0.28.19(typescript@5.9.3)):
     dependencies:
       typedoc: 0.28.19(typescript@5.8.3)
 
-  typedoc-plugin-mermaid@1.12.0(typedoc@0.28.19(typescript@5.8.3)):
+  typedoc-plugin-mermaid@1.12.0(typedoc@0.28.19(typescript@5.9.3)):
     dependencies:
       html-escaper: 3.0.3
       typedoc: 0.28.19(typescript@5.8.3)
 
-  typedoc-plugin-missing-exports@4.1.3(typedoc@0.28.19(typescript@5.8.3)):
+  typedoc-plugin-missing-exports@4.1.3(typedoc@0.28.19(typescript@5.9.3)):
     dependencies:
       typedoc: 0.28.19(typescript@5.8.3)
 
@@ -27935,7 +28582,7 @@ snapshots:
 
   typescript-eslint@8.58.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.8.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.58.2(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.8.3)
+      '@typescript-eslint/eslint-plugin': 8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.8.3)
       '@typescript-eslint/parser': 8.58.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.8.3)
       '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.8.3)
       '@typescript-eslint/utils': 8.58.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.8.3)


### PR DESCRIPTION
## Summary

First implementation chunk for [ADR 0025 — Public-Good Gateway Registry](https://github.com/olane-labs/o-twin-data-pipeline/pull/494). Lands the package shell, on-the-wire types, and the naming-policy validator. The resolver itself, `did:web` resolution, and signature verification land in subsequent stacked PRs.

This PR targets the integration branch `brendon/0025-public-good-gateway-registry`, **not** `main`. The integration branch will be merged to `main` once the full v0 chain (skeleton → resolver core → did:web + signatures → o-client wiring → CLI → smoke) is stacked and reviewed.

## What's in this PR

- `src/interfaces/registry-entry.ts` — `GatewayRegistryEntry`, `SignatureBlock`
- `src/interfaces/registry-snapshot.ts` — `RegistrySnapshot`, `SnapshotSignature`
- `src/interfaces/resolver-config.ts` — `GatewayRegistryResolverConfig`
- `src/registry/reserved-names.ts` — `RESERVED_GATEWAY_NAMES`, `isReservedGatewayName()`, `validateGatewayName()`
- `test/reserved-names.test.ts` — 16 tests (all pass)
- `jest.config.cjs` — ts-jest ESM preset (first working ts-jest+ESM setup in this monorepo; sibling packages declare jest but don't actually run it)
- `README.md` linking back to ADR 0025

## Naming policy (locked by ADR 0025)

A gateway name is:
- Lowercase ASCII letters, digits, and hyphens
- 2–63 characters (DNS-label compatible — keeps \`did:web\` upgrades cheap)
- No leading or trailing hyphen
- Not a reserved name

Reserved: \`olane\`, \`localhost\`, \`local\`, \`leader\`, \`lane\`, \`registry\`, \`internal\`, plus all single-character names.

## Test plan

- [x] \`pnpm install\` clean
- [x] \`pnpm run build\` clean
- [x] \`pnpm run test\` — 16/16 pass
- [ ] Reviewer confirms package layout matches sibling conventions (\`o-gateway-interface\`, \`o-gateway-olane\`)
- [ ] Reviewer confirms the type shape covers what the resolver needs in the next PR
- [ ] Reviewer confirms reservation list matches ADR 0025 §"Naming Policy"

🤖 Generated with [Claude Code](https://claude.com/claude-code)