### PR TITLE
feat(o-gateway-registry): GatewayRegistryResolver core (ADR 0025)

### DIFF
--- a/packages/o-gateway-registry/package.json
+++ b/packages/o-gateway-registry/package.json
@@ -54,6 +54,7 @@
     "@olane/o-config": "0.9.0",
     "@olane/o-core": "0.9.0",
     "@olane/o-gateway-interface": "0.9.0",
+    "@olane/o-node": "0.9.0",
     "@olane/o-protocol": "0.9.0",
     "debug": "^4.4.3",
     "dotenv": "^17.3.1"

--- a/packages/o-gateway-registry/src/registry/gateway-registry-resolver.ts
+++ b/packages/o-gateway-registry/src/registry/gateway-registry-resolver.ts
@@ -1,0 +1,179 @@
+import {
+  oAddress,
+  oAddressResolver,
+  oCustomTransport,
+  oTransport,
+  ResolveRequest,
+  RouteResponse,
+} from '@olane/o-core';
+import { oNodeTransport } from '@olane/o-node';
+import { GatewayRegistryResolverConfig } from '../interfaces/resolver-config.js';
+import {
+  GatewayRegistryEntry,
+  RegistrySnapshot,
+} from '../interfaces/index.js';
+import {
+  HttpsSnapshotFetcher,
+  SnapshotFetcher,
+} from './snapshot-fetcher.js';
+import {
+  AlwaysAcceptVerifier,
+  SnapshotVerifier,
+} from './snapshot-verifier.js';
+import { isReservedGatewayName } from './reserved-names.js';
+
+/**
+ * Resolves the first path segment of an `o://` address — the gateway
+ * namespace — to a libp2p multiaddr by reading a pinned, signed
+ * snapshot of the public-good registry at
+ * `github.com/olane-labs/gateway-registry`.
+ *
+ * Slot in the resolver chain: ahead of `oGatewayResolver`. If this
+ * resolver matches the first segment against a verified registry
+ * entry, it returns the gateway leader's transports as the next hop.
+ * If no entry matches, it passes through and the chain falls back to
+ * the legacy `oGatewayResolver` (which still handles `o://olane`).
+ *
+ * Reserved names (`olane`, `localhost`, `local`, `leader`, `lane`,
+ * `registry`, `internal`, single-character) always pass through. The
+ * resolver never claims a reserved namespace even if a registry entry
+ * for it somehow exists — registry validation happens at publication
+ * time, but the resolver is defense-in-depth.
+ *
+ * Construction is cheap. Loading the snapshot is async. Call
+ * `load()` once at startup, or rely on the lazy `resolve()` path
+ * (first resolve fetches; subsequent resolves use the cached
+ * snapshot).
+ */
+export class GatewayRegistryResolver extends oAddressResolver {
+  private snapshot: RegistrySnapshot | null = null;
+  private snapshotFetchedAt: number | null = null;
+  private loadingPromise: Promise<void> | null = null;
+
+  constructor(
+    address: oAddress,
+    private readonly config: GatewayRegistryResolverConfig,
+    private readonly fetcher: SnapshotFetcher = new HttpsSnapshotFetcher(),
+    private readonly verifier: SnapshotVerifier = new AlwaysAcceptVerifier(),
+  ) {
+    super(address);
+  }
+
+  get customTransports(): oTransport[] {
+    return [new oCustomTransport('/registry')];
+  }
+
+  /**
+   * Eagerly load the snapshot. Idempotent — a second concurrent call
+   * awaits the in-flight fetch instead of issuing a duplicate request.
+   * Resolver consumers SHOULD call this once at process startup.
+   */
+  async load(): Promise<void> {
+    if (this.loadingPromise) {
+      return this.loadingPromise;
+    }
+    this.loadingPromise = this.doLoad();
+    try {
+      await this.loadingPromise;
+    } finally {
+      this.loadingPromise = null;
+    }
+  }
+
+  private async doLoad(): Promise<void> {
+    const snapshot = await this.fetcher.fetch(this.config.snapshotUrl);
+    await this.verifier.verifySnapshot(
+      snapshot,
+      this.config.expectedMaintainerDid,
+    );
+    this.snapshot = snapshot;
+    this.snapshotFetchedAt = Date.now();
+  }
+
+  private isStale(): boolean {
+    if (!this.snapshotFetchedAt) return true;
+    const ttl = this.config.maxCacheAgeMs ?? 60 * 60 * 1000;
+    return Date.now() - this.snapshotFetchedAt > ttl;
+  }
+
+  /**
+   * Returns the entry for `name`, or null if no entry matches, the name
+   * is reserved, or the entry fails per-entry verification.
+   *
+   * Per-entry verification is best-effort: an individual entry that
+   * fails verification is dropped silently, while a snapshot-level
+   * verification failure throws. This matches the security posture of
+   * X.509 — one bad cert in a chain doesn't poison the rest.
+   */
+  async lookup(name: string): Promise<GatewayRegistryEntry | null> {
+    if (isReservedGatewayName(name)) {
+      return null;
+    }
+    if (!this.snapshot || this.isStale()) {
+      try {
+        await this.load();
+      } catch (err) {
+        if (this.config.failClosed !== false) {
+          throw err;
+        }
+        return null;
+      }
+    }
+    const entry = this.snapshot!.entries.find((e) => e.name === name);
+    if (!entry) {
+      return null;
+    }
+    try {
+      await this.verifier.verifyEntry(entry);
+    } catch {
+      return null;
+    }
+    return { ...entry, verifiedAt: new Date().toISOString() };
+  }
+
+  async resolve(request: ResolveRequest): Promise<RouteResponse> {
+    const { address, targetAddress, request: resolveRequest } = request;
+    const firstSegment = address.paths.split('/')[0];
+
+    // Empty paths (e.g., a bare `o://` somehow) — pass through, let the
+    // chain handle it. Defensive — the caller upstream should reject
+    // these earlier.
+    if (!firstSegment) {
+      return passthrough(address, targetAddress, resolveRequest);
+    }
+
+    // Reserved names — always pass through. The legacy
+    // `oGatewayResolver` handles `o://olane`; other reservations have
+    // no legitimate registry entry.
+    if (isReservedGatewayName(firstSegment)) {
+      return passthrough(address, targetAddress, resolveRequest);
+    }
+
+    const entry = await this.lookup(firstSegment);
+    if (!entry) {
+      return passthrough(address, targetAddress, resolveRequest);
+    }
+
+    const gatewayLeader = oAddress.leader();
+    gatewayLeader.setTransports(
+      entry.transports.map((t) => new oNodeTransport(t)),
+    );
+    return {
+      nextHopAddress: gatewayLeader,
+      targetAddress: targetAddress,
+      requestOverride: resolveRequest,
+    };
+  }
+}
+
+function passthrough(
+  address: oAddress,
+  targetAddress: oAddress,
+  requestOverride: ResolveRequest['request'],
+): RouteResponse {
+  return {
+    nextHopAddress: address,
+    targetAddress: targetAddress,
+    requestOverride,
+  };
+}

--- a/packages/o-gateway-registry/src/registry/index.ts
+++ b/packages/o-gateway-registry/src/registry/index.ts
@@ -1,1 +1,4 @@
 export * from './reserved-names.js';
+export * from './snapshot-fetcher.js';
+export * from './snapshot-verifier.js';
+export * from './gateway-registry-resolver.js';

--- a/packages/o-gateway-registry/src/registry/snapshot-fetcher.ts
+++ b/packages/o-gateway-registry/src/registry/snapshot-fetcher.ts
@@ -1,0 +1,69 @@
+import { RegistrySnapshot } from '../interfaces/registry-snapshot.js';
+
+/**
+ * Fetches a signed registry snapshot.
+ *
+ * The interface is deliberately narrow so tests can substitute an
+ * in-memory fixture for the HTTPS implementation. Production code uses
+ * `HttpsSnapshotFetcher`; tests use `StaticSnapshotFetcher` (this module)
+ * or write their own.
+ *
+ * Implementations MUST NOT verify signatures — that is the resolver's
+ * job. The fetcher's only contract is: "give me the bytes at this URL,
+ * parsed as JSON, conforming to `RegistrySnapshot` shape." If the bytes
+ * are malformed or unreachable, throw.
+ */
+export interface SnapshotFetcher {
+  fetch(url: string): Promise<RegistrySnapshot>;
+}
+
+/**
+ * Fetches the snapshot over HTTPS with `globalThis.fetch`.
+ *
+ * Node 20+ ships a built-in `fetch`, so no additional dependency. The
+ * implementation enforces HTTPS at the call site — `http://` URLs throw
+ * synchronously. Mirrors that serve over plain HTTP are not supported in
+ * v0 (the snapshot signature provides integrity, but plain HTTP allows
+ * downgrade-and-stall attacks against availability).
+ */
+export class HttpsSnapshotFetcher implements SnapshotFetcher {
+  async fetch(url: string): Promise<RegistrySnapshot> {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'https:') {
+      throw new Error(
+        `snapshot fetcher requires HTTPS, got "${parsed.protocol}//${parsed.host}"`,
+      );
+    }
+    const response = await globalThis.fetch(url, {
+      headers: { Accept: 'application/json' },
+    });
+    if (!response.ok) {
+      throw new Error(
+        `snapshot fetch failed: ${response.status} ${response.statusText} for ${url}`,
+      );
+    }
+    const body = (await response.json()) as RegistrySnapshot;
+    if (body?.schemaVersion !== 1) {
+      throw new Error(
+        `unsupported registry snapshot schemaVersion: ${body?.schemaVersion}`,
+      );
+    }
+    if (!Array.isArray(body.entries)) {
+      throw new Error('registry snapshot is missing or has invalid `entries`');
+    }
+    return body;
+  }
+}
+
+/**
+ * Test-only fetcher. Returns whatever snapshot it was constructed with.
+ * Useful for unit tests of the resolver where signature verification is
+ * stubbed and the network is not involved.
+ */
+export class StaticSnapshotFetcher implements SnapshotFetcher {
+  constructor(private readonly snapshot: RegistrySnapshot) {}
+
+  async fetch(_url: string): Promise<RegistrySnapshot> {
+    return this.snapshot;
+  }
+}

--- a/packages/o-gateway-registry/src/registry/snapshot-verifier.ts
+++ b/packages/o-gateway-registry/src/registry/snapshot-verifier.ts
@@ -1,0 +1,66 @@
+import {
+  GatewayRegistryEntry,
+  RegistrySnapshot,
+} from '../interfaces/index.js';
+
+/**
+ * Verifies a snapshot before the resolver trusts it.
+ *
+ * v0 ships an interface and a stub. **Real signature verification lands
+ * in the next stacked PR (DidWebResolver + SignatureVerifier)**, where
+ * we wire `did:web` resolution and Ed25519 signature checks. This stub
+ * is here so the resolver's call sites are stable across the two PRs —
+ * the resolver depends on `SnapshotVerifier`, not on the verification
+ * mechanism, so swapping in the real impl is a one-line change in the
+ * factory.
+ *
+ * Tests that need to bypass verification use `AlwaysAcceptVerifier`.
+ * Tests that need to assert verification was called use a spy
+ * implementation.
+ */
+export interface SnapshotVerifier {
+  /**
+   * Verify the snapshot's maintainer signature. Throws if invalid.
+   *
+   * @param snapshot The snapshot as fetched.
+   * @param expectedMaintainerDid The DID the resolver was configured to
+   *   trust. The verifier MUST refuse the snapshot if its
+   *   `maintainerSignature.maintainerDid` does not equal this value.
+   */
+  verifySnapshot(
+    snapshot: RegistrySnapshot,
+    expectedMaintainerDid: string,
+  ): Promise<void>;
+
+  /**
+   * Verify a single gateway entry's operator signature. Throws if
+   * invalid. The resolver calls this for each entry it intends to
+   * surface; entries that fail verification are dropped, not returned.
+   */
+  verifyEntry(entry: GatewayRegistryEntry): Promise<void>;
+}
+
+/**
+ * v0 stub — accepts everything. Replaced by the real `did:web`-backed
+ * verifier in the next stacked PR. Tests can use this directly.
+ *
+ * The class name is deliberately ugly so a code search for
+ * `AlwaysAcceptVerifier` flags every place a real verifier needs to be
+ * substituted. Production code MUST NOT instantiate this class.
+ */
+export class AlwaysAcceptVerifier implements SnapshotVerifier {
+  async verifySnapshot(
+    snapshot: RegistrySnapshot,
+    expectedMaintainerDid: string,
+  ): Promise<void> {
+    if (snapshot.maintainerSignature?.maintainerDid !== expectedMaintainerDid) {
+      throw new Error(
+        `snapshot maintainer DID mismatch: expected "${expectedMaintainerDid}", got "${snapshot.maintainerSignature?.maintainerDid}"`,
+      );
+    }
+  }
+
+  async verifyEntry(_entry: GatewayRegistryEntry): Promise<void> {
+    // intentionally empty in v0 stub
+  }
+}

--- a/packages/o-gateway-registry/test/fixtures/snapshot.ts
+++ b/packages/o-gateway-registry/test/fixtures/snapshot.ts
@@ -1,0 +1,51 @@
+import {
+  GatewayRegistryEntry,
+  RegistrySnapshot,
+} from '../../src/interfaces/index.js';
+
+const TEST_MAINTAINER_DID = 'did:web:registry.olane.network';
+
+export function makeEntry(
+  overrides: Partial<GatewayRegistryEntry> = {},
+): GatewayRegistryEntry {
+  return {
+    name: 'meta',
+    operatorDid: 'did:web:meta.example.com',
+    transports: ['/dns4/leader.meta.example.com/tcp/4000/tls/ws'],
+    description: 'Meta operator gateway (test fixture)',
+    logo: '',
+    website: 'https://meta.example.com',
+    defaultCapabilityClass: 'side-effecting',
+    publishedAt: '2026-05-09T00:00:00Z',
+    signature: {
+      keyId: 'did:web:meta.example.com#key-1',
+      algorithm: 'Ed25519',
+      value: 'AAAA',
+    },
+    ...overrides,
+  };
+}
+
+export function makeSnapshot(
+  entries: GatewayRegistryEntry[],
+  overrides: Partial<RegistrySnapshot> = {},
+): RegistrySnapshot {
+  return {
+    schemaVersion: 1,
+    pinnedCommit: 'abc123',
+    generatedAt: '2026-05-09T00:00:00Z',
+    entries,
+    maintainerSignature: {
+      maintainerDid: TEST_MAINTAINER_DID,
+      keyId: `${TEST_MAINTAINER_DID}#key-1`,
+      algorithm: 'Ed25519',
+      value: 'AAAA',
+    },
+    ...overrides,
+  };
+}
+
+export const TEST_CONFIG = {
+  snapshotUrl: 'https://registry.olane.network/v0/snapshot.json',
+  expectedMaintainerDid: TEST_MAINTAINER_DID,
+};

--- a/packages/o-gateway-registry/test/gateway-registry-resolver.test.ts
+++ b/packages/o-gateway-registry/test/gateway-registry-resolver.test.ts
@@ -1,0 +1,218 @@
+import { oAddress } from '@olane/o-core';
+import {
+  GatewayRegistryResolver,
+  StaticSnapshotFetcher,
+  AlwaysAcceptVerifier,
+  SnapshotFetcher,
+  SnapshotVerifier,
+} from '../src/index.js';
+import {
+  RegistrySnapshot,
+  GatewayRegistryEntry,
+} from '../src/interfaces/index.js';
+import { makeEntry, makeSnapshot, TEST_CONFIG } from './fixtures/snapshot.js';
+
+function makeResolver(
+  snapshot: RegistrySnapshot,
+  opts: { verifier?: SnapshotVerifier; fetcher?: SnapshotFetcher } = {},
+): GatewayRegistryResolver {
+  const fetcher = opts.fetcher ?? new StaticSnapshotFetcher(snapshot);
+  const verifier = opts.verifier ?? new AlwaysAcceptVerifier();
+  return new GatewayRegistryResolver(
+    new oAddress('o://registry'),
+    TEST_CONFIG,
+    fetcher,
+    verifier,
+  );
+}
+
+function makeRequest(uri: string) {
+  const address = new oAddress(uri);
+  return {
+    address,
+    targetAddress: address,
+    node: {} as never,
+  };
+}
+
+describe('GatewayRegistryResolver — load() lifecycle', () => {
+  test('load() fetches the snapshot once and verifies it', async () => {
+    const snapshot = makeSnapshot([makeEntry({ name: 'meta' })]);
+    const verifyCalls: Array<{ snap: RegistrySnapshot; did: string }> = [];
+    const verifier: SnapshotVerifier = {
+      async verifySnapshot(snap, did) {
+        verifyCalls.push({ snap, did });
+      },
+      async verifyEntry() {},
+    };
+    const resolver = makeResolver(snapshot, { verifier });
+
+    await resolver.load();
+
+    expect(verifyCalls).toHaveLength(1);
+    expect(verifyCalls[0].snap).toBe(snapshot);
+    expect(verifyCalls[0].did).toBe(TEST_CONFIG.expectedMaintainerDid);
+  });
+
+  test('load() is concurrency-safe — two simultaneous calls share one fetch', async () => {
+    const snapshot = makeSnapshot([makeEntry()]);
+    let fetchCount = 0;
+    const fetcher: SnapshotFetcher = {
+      async fetch() {
+        fetchCount += 1;
+        return snapshot;
+      },
+    };
+    const resolver = makeResolver(snapshot, { fetcher });
+
+    await Promise.all([resolver.load(), resolver.load()]);
+
+    expect(fetchCount).toBe(1);
+  });
+
+  test('load() rejects a snapshot whose maintainer DID does not match config', async () => {
+    const snapshot = makeSnapshot([makeEntry()], {
+      maintainerSignature: {
+        maintainerDid: 'did:web:wrong.example.com',
+        keyId: 'did:web:wrong.example.com#key-1',
+        algorithm: 'Ed25519',
+        value: 'AAAA',
+      },
+    });
+    const resolver = makeResolver(snapshot);
+
+    await expect(resolver.load()).rejects.toThrow(/maintainer DID/);
+  });
+});
+
+describe('GatewayRegistryResolver — resolve()', () => {
+  test('routes to the gateway transport when first segment matches an entry', async () => {
+    const entry = makeEntry({
+      name: 'meta',
+      transports: ['/dns4/leader.meta.example.com/tcp/4000/tls/ws'],
+    });
+    const resolver = makeResolver(makeSnapshot([entry]));
+
+    const result = await resolver.resolve(
+      makeRequest('o://meta/brendon/shell'),
+    );
+
+    expect(result.nextHopAddress.toString()).toBe('o://leader');
+    const transports = result.nextHopAddress.transports.map((t) => t.value);
+    expect(transports).toEqual([
+      '/dns4/leader.meta.example.com/tcp/4000/tls/ws',
+    ]);
+  });
+
+  test('passes through when no entry matches the first segment', async () => {
+    const resolver = makeResolver(makeSnapshot([]));
+
+    const req = makeRequest('o://unknown-gateway/foo');
+    const result = await resolver.resolve(req);
+
+    expect(result.nextHopAddress).toBe(req.address);
+  });
+
+  test('passes through reserved names even if the snapshot somehow has a matching entry', async () => {
+    const entry = makeEntry({ name: 'olane' });
+    const resolver = makeResolver(makeSnapshot([entry]));
+
+    const req = makeRequest('o://olane/some-tool');
+    const result = await resolver.resolve(req);
+
+    expect(result.nextHopAddress).toBe(req.address);
+  });
+
+  test('passes through reserved single-character names', async () => {
+    const resolver = makeResolver(makeSnapshot([makeEntry({ name: 'a' })]));
+
+    const req = makeRequest('o://a/foo');
+    const result = await resolver.resolve(req);
+
+    expect(result.nextHopAddress).toBe(req.address);
+  });
+
+  test('drops entries that fail per-entry verification rather than throwing', async () => {
+    const entry = makeEntry({ name: 'meta' });
+    const verifier: SnapshotVerifier = {
+      async verifySnapshot() {
+        // accept the snapshot
+      },
+      async verifyEntry(e: GatewayRegistryEntry) {
+        if (e.name === 'meta') throw new Error('forged entry');
+      },
+    };
+    const resolver = makeResolver(makeSnapshot([entry]), { verifier });
+
+    const req = makeRequest('o://meta/brendon');
+    const result = await resolver.resolve(req);
+
+    expect(result.nextHopAddress).toBe(req.address);
+  });
+
+  test('lazy-loads the snapshot on first resolve when load() was not called', async () => {
+    const snapshot = makeSnapshot([makeEntry({ name: 'meta' })]);
+    let fetchCount = 0;
+    const fetcher: SnapshotFetcher = {
+      async fetch() {
+        fetchCount += 1;
+        return snapshot;
+      },
+    };
+    const resolver = makeResolver(snapshot, { fetcher });
+
+    await resolver.resolve(makeRequest('o://meta/x'));
+
+    expect(fetchCount).toBe(1);
+  });
+
+  test('lookup() of a reserved name short-circuits and never fetches', async () => {
+    const snapshot = makeSnapshot([makeEntry({ name: 'meta' })]);
+    let fetchCount = 0;
+    const fetcher: SnapshotFetcher = {
+      async fetch() {
+        fetchCount += 1;
+        return snapshot;
+      },
+    };
+    const resolver = makeResolver(snapshot, { fetcher });
+
+    const result = await resolver.lookup('olane');
+
+    expect(result).toBeNull();
+    expect(fetchCount).toBe(0);
+  });
+});
+
+describe('GatewayRegistryResolver — error posture', () => {
+  test('failClosed=true (default) throws when the fetch fails', async () => {
+    const fetcher: SnapshotFetcher = {
+      async fetch() {
+        throw new Error('network down');
+      },
+    };
+    const resolver = new GatewayRegistryResolver(
+      new oAddress('o://registry'),
+      TEST_CONFIG,
+      fetcher,
+    );
+
+    await expect(resolver.lookup('meta')).rejects.toThrow(/network down/);
+  });
+
+  test('failClosed=false returns null when the fetch fails (test mode only)', async () => {
+    const fetcher: SnapshotFetcher = {
+      async fetch() {
+        throw new Error('network down');
+      },
+    };
+    const resolver = new GatewayRegistryResolver(
+      new oAddress('o://registry'),
+      { ...TEST_CONFIG, failClosed: false },
+      fetcher,
+    );
+
+    const result = await resolver.lookup('meta');
+    expect(result).toBeNull();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -781,6 +781,9 @@ importers:
       '@olane/o-gateway-interface':
         specifier: 0.9.0
         version: 0.9.0
+      '@olane/o-node':
+        specifier: 0.9.0
+        version: 0.9.0
       '@olane/o-protocol':
         specifier: 0.9.0
         version: 0.9.0
@@ -19256,9 +19259,9 @@ snapshots:
       strong-log-transformer: 2.1.0
       tempy: 3.2.0
       typedoc: 0.28.19(typescript@5.8.3)
-      typedoc-plugin-mdn-links: 5.1.1(typedoc@0.28.19(typescript@5.9.3))
-      typedoc-plugin-mermaid: 1.12.0(typedoc@0.28.19(typescript@5.9.3))
-      typedoc-plugin-missing-exports: 4.1.3(typedoc@0.28.19(typescript@5.9.3))
+      typedoc-plugin-mdn-links: 5.1.1(typedoc@0.28.19(typescript@5.8.3))
+      typedoc-plugin-mermaid: 1.12.0(typedoc@0.28.19(typescript@5.8.3))
+      typedoc-plugin-missing-exports: 4.1.3(typedoc@0.28.19(typescript@5.8.3))
       typescript: 5.8.3
       typescript-docs-verifier: 3.0.2(typescript@5.8.3)
       wherearewe: 2.0.1
@@ -19363,9 +19366,9 @@ snapshots:
       strong-log-transformer: 2.1.0
       tempy: 3.2.0
       typedoc: 0.28.19(typescript@5.8.3)
-      typedoc-plugin-mdn-links: 5.1.1(typedoc@0.28.19(typescript@5.9.3))
-      typedoc-plugin-mermaid: 1.12.0(typedoc@0.28.19(typescript@5.9.3))
-      typedoc-plugin-missing-exports: 4.1.3(typedoc@0.28.19(typescript@5.9.3))
+      typedoc-plugin-mdn-links: 5.1.1(typedoc@0.28.19(typescript@5.8.3))
+      typedoc-plugin-mermaid: 1.12.0(typedoc@0.28.19(typescript@5.8.3))
+      typedoc-plugin-missing-exports: 4.1.3(typedoc@0.28.19(typescript@5.8.3))
       typescript: 5.8.3
       typescript-docs-verifier: 3.0.2(typescript@5.8.3)
       wherearewe: 2.0.1
@@ -28551,16 +28554,16 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typedoc-plugin-mdn-links@5.1.1(typedoc@0.28.19(typescript@5.9.3)):
+  typedoc-plugin-mdn-links@5.1.1(typedoc@0.28.19(typescript@5.8.3)):
     dependencies:
       typedoc: 0.28.19(typescript@5.8.3)
 
-  typedoc-plugin-mermaid@1.12.0(typedoc@0.28.19(typescript@5.9.3)):
+  typedoc-plugin-mermaid@1.12.0(typedoc@0.28.19(typescript@5.8.3)):
     dependencies:
       html-escaper: 3.0.3
       typedoc: 0.28.19(typescript@5.8.3)
 
-  typedoc-plugin-missing-exports@4.1.3(typedoc@0.28.19(typescript@5.9.3)):
+  typedoc-plugin-missing-exports@4.1.3(typedoc@0.28.19(typescript@5.8.3)):
     dependencies:
       typedoc: 0.28.19(typescript@5.8.3)
 


### PR DESCRIPTION
## Summary

Second chunk for ADR 0025. Lands the registry resolver and the substrate it sits on (fetcher + verifier interfaces). The next stacked PR replaces the `AlwaysAcceptVerifier` stub with real `did:web` + Ed25519.

**Stacked on** [#204](https://github.com/olane-labs/olane/pull/204) (skeleton). Base is the skeleton branch, not the integration branch — once #204 merges, GitHub auto-retargets this PR.

## What's in this PR

- `src/registry/snapshot-fetcher.ts` — `SnapshotFetcher` interface, `HttpsSnapshotFetcher` (HTTPS-only, refuses plain HTTP), `StaticSnapshotFetcher` (test-only)
- `src/registry/snapshot-verifier.ts` — `SnapshotVerifier` interface, `AlwaysAcceptVerifier` (v0 stub; real verifier lands next PR)
- `src/registry/gateway-registry-resolver.ts` — `GatewayRegistryResolver` extends `oAddressResolver`. First-segment match returns gateway leader transports; no match passes through; reserved names always pass through.
- `test/fixtures/snapshot.ts` — fixture builders
- `test/gateway-registry-resolver.test.ts` — 12 new tests

## Design notes worth a look

- **Concurrency-safe `load()`** — two simultaneous calls share the in-flight fetch instead of issuing duplicates.
- **Per-entry verification failures DROP the entry rather than throw** (X.509 chain semantics — one bad entry doesn't poison the snapshot).
- **Snapshot-level signature failure throws** (fail-closed by default; `failClosed: false` is test-only).
- **Reserved names short-circuit** before the snapshot loads — saves a fetch for \`o://olane/...\` and friends.
- **Lazy load**: \`resolve()\` loads on first call if \`load()\` wasn't pre-called.

## Test plan

- [x] \`pnpm run build\` clean
- [x] \`pnpm run test\` — 28/28 pass (16 from skeleton + 12 new)
- [ ] Reviewer confirms the resolver chain semantics (pass-through vs. claim) match the existing \`oGatewayResolver\` pattern
- [ ] Reviewer confirms fail-closed default is appropriate for production
- [ ] Reviewer confirms the per-entry-drop posture (rather than fail-the-whole-snapshot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)