### PR TITLE
feat(o-gateway-registry): did:web resolver + Ed25519 signature verification (ADR 0025)

### DIFF
--- a/packages/o-gateway-registry/README.md
+++ b/packages/o-gateway-registry/README.md
@@ -9,7 +9,7 @@ gateway namespace — to a libp2p multiaddr by reading a pinned snapshot of
 the public-good registry at `github.com/olane-labs/gateway-registry`.
 
 ```
-o://meta/brendon/shell
+o://copass/brendon/shell
    └──┘  ← this segment is what we resolve
 ```
 
@@ -18,7 +18,7 @@ o://meta/brendon/shell
 Today, `o://` resolves through a single hard-coded gateway (`o://olane` →
 `leader.olane.com`). One gateway is a product, not a network. The registry
 layer is the substrate that lets multiple operators host slices of the
-network — Meta, Anthropic, an enterprise on its own infrastructure, an
+network — Copass, Anthropic, an enterprise on its own infrastructure, an
 indie hacker on a Raspberry Pi — each authoritative for their own users,
 all rooted in a common, auditable, mirror-able directory.
 
@@ -42,7 +42,7 @@ End-to-end smoke is the final PR in the v0 chain.
 
 See [ADR 0025 §"Phasing"][adr-phasing] for the full sequence and
 [ADR 0025 §"Resolution Flow"][adr-flow] for the on-the-wire walkthrough
-of `o://meta/brendon/shell` → libp2p stream.
+of `o://copass/brendon/shell` → libp2p stream.
 
 [adr-phasing]: https://github.com/olane-labs/o-twin-data-pipeline/blob/staging/docs/adr/0025-public-good-gateway-registry.md#phasing
 [adr-flow]: https://github.com/olane-labs/o-twin-data-pipeline/blob/staging/docs/adr/0025-public-good-gateway-registry.md#resolution-flow--concrete-walk-through

--- a/packages/o-gateway-registry/src/canonical/canonicalize.ts
+++ b/packages/o-gateway-registry/src/canonical/canonicalize.ts
@@ -1,0 +1,70 @@
+/**
+ * RFC 8785 (JSON Canonicalization Scheme) — minimal subset.
+ *
+ * Canonicalization is required for signing and verification to be
+ * deterministic across clients. Two parties must serialize the same
+ * object to the same bytes, otherwise a valid signature looks invalid
+ * to the verifier.
+ *
+ * Subset implemented:
+ *   - Object keys sorted lexicographically (UTF-16 code-point order
+ *     per RFC 8785 §3.2).
+ *   - No insignificant whitespace.
+ *   - Strings escaped per RFC 8785 §3.2.2.4 (ASCII-printable except for
+ *     `"` and `\`; control chars use `\u00XX`).
+ *   - Numbers serialized via `Number.prototype.toString()` for integers
+ *     and finite floats. RFC 8785 mandates ECMA-404-compliant number
+ *     formatting; v0 only supports integers + ISO-8601 strings, so
+ *     tight-rope number formatting is out of scope.
+ *   - `null`, `true`, `false` literal.
+ *
+ * Not implemented (out of scope for v0; sufficient for our payload
+ * shape):
+ *   - Floats with high precision (we don't sign floats).
+ *   - BigInt (we don't serialize BigInt).
+ *   - `undefined` (rejected — RFC 8785 doesn't accept it).
+ *
+ * If the input contains a value the canonicalizer doesn't know how to
+ * serialize, it throws — silent acceptance would produce a string that
+ * verifies "successfully" but doesn't match what the signer signed.
+ */
+export function canonicalize(value: unknown): string {
+  if (value === null) return 'null';
+  if (value === true) return 'true';
+  if (value === false) return 'false';
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new Error('canonicalize: non-finite number');
+    }
+    return String(value);
+  }
+  if (typeof value === 'string') {
+    return encodeString(value);
+  }
+  if (Array.isArray(value)) {
+    return '[' + value.map(canonicalize).join(',') + ']';
+  }
+  if (typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+    const keys = Object.keys(obj)
+      .filter((k) => obj[k] !== undefined)
+      .sort();
+    return (
+      '{' +
+      keys
+        .map((k) => encodeString(k) + ':' + canonicalize(obj[k]))
+        .join(',') +
+      '}'
+    );
+  }
+  throw new Error(`canonicalize: unsupported type ${typeof value}`);
+}
+
+function encodeString(s: string): string {
+  // JSON.stringify already escapes control chars and quotes correctly;
+  // the only deviation from RFC 8785 is that JSON.stringify is allowed
+  // to escape `/` (it doesn't), and forward slash escaping is optional
+  // per the RFC. v0 is consistent with both signers and verifiers using
+  // the same library, so we accept JSON.stringify's exact output.
+  return JSON.stringify(s);
+}

--- a/packages/o-gateway-registry/src/canonical/index.ts
+++ b/packages/o-gateway-registry/src/canonical/index.ts
@@ -1,0 +1,2 @@
+export * from './canonicalize.js';
+export * from './signing-payload.js';

--- a/packages/o-gateway-registry/src/canonical/signing-payload.ts
+++ b/packages/o-gateway-registry/src/canonical/signing-payload.ts
@@ -1,0 +1,38 @@
+import {
+  GatewayRegistryEntry,
+  RegistrySnapshot,
+} from '../interfaces/index.js';
+import { canonicalize } from './canonicalize.js';
+
+/**
+ * Strips the verification-only fields from an entry and returns the
+ * canonical bytes that the operator's signature is computed over.
+ *
+ * The operator signs the entry MINUS its own `signature` field (a chicken-
+ * and-egg problem otherwise) and MINUS `verifiedAt` (populated only after
+ * verification — never present at signing time).
+ */
+export function entrySigningPayload(entry: GatewayRegistryEntry): Uint8Array {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { signature, verifiedAt, ...signed } = entry;
+  return new TextEncoder().encode(canonicalize(signed));
+}
+
+/**
+ * Strips the maintainer signature and returns the canonical bytes the
+ * registry-maintainer key signs over.
+ *
+ * Note: the snapshot signature covers the entries (which themselves are
+ * already-signed objects). This is intentional — the maintainer is
+ * attesting "I served this set of entries at this commit at this time,"
+ * not re-attesting the entries' contents. An entry whose own signature
+ * fails will be dropped by the verifier even if the snapshot signature
+ * is valid.
+ */
+export function snapshotSigningPayload(
+  snapshot: RegistrySnapshot,
+): Uint8Array {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { maintainerSignature, ...signed } = snapshot;
+  return new TextEncoder().encode(canonicalize(signed));
+}

--- a/packages/o-gateway-registry/src/did/did-document.ts
+++ b/packages/o-gateway-registry/src/did/did-document.ts
@@ -1,0 +1,34 @@
+/**
+ * Minimal subset of the W3C DID Core DID Document model.
+ *
+ * https://www.w3.org/TR/did-core/#did-documents
+ *
+ * v0 only consumes Ed25519 verification methods of type
+ * `Ed25519VerificationKey2020`, with the public key encoded as
+ * multibase base58btc per `publicKeyMultibase`. Other key types
+ * (JsonWebKey2020, secp256k1, etc.) are silently ignored — the
+ * verifier returns "no key found" and the entry is dropped.
+ *
+ * This narrow surface is deliberate. v0 is operator-friendly enough
+ * (a `did:web` document hosted at `.well-known/did.json` with one
+ * Ed25519 key is roughly 8 lines of JSON), and v1 will expand to
+ * additional key types as needed.
+ */
+export interface DidDocument {
+  '@context'?: string | string[];
+  id: string;
+  verificationMethod?: VerificationMethod[];
+  assertionMethod?: Array<string | VerificationMethod>;
+}
+
+export interface VerificationMethod {
+  id: string;
+  type: string;
+  controller: string;
+
+  /** Ed25519 public key, multibase-encoded with prefix `z`. */
+  publicKeyMultibase?: string;
+
+  /** Alternative encoding the verifier doesn't use in v0. */
+  publicKeyJwk?: unknown;
+}

--- a/packages/o-gateway-registry/src/did/did-web-resolver.ts
+++ b/packages/o-gateway-registry/src/did/did-web-resolver.ts
@@ -1,0 +1,84 @@
+import { DidDocument } from './did-document.js';
+
+/**
+ * Resolves a `did:web` DID to its DID document.
+ *
+ * https://w3c-ccg.github.io/did-method-web/
+ *
+ * Algorithm:
+ *   - `did:web:example.com`           → `https://example.com/.well-known/did.json`
+ *   - `did:web:example.com:user:alice` → `https://example.com/user/alice/did.json`
+ *   - `did:web:example.com%3A8443`    → `https://example.com:8443/.well-known/did.json`
+ *
+ * v0 is HTTPS-only and refuses any non-HTTPS URL synthesized from the
+ * DID. Localhost is allowed for tests when the resolver is constructed
+ * with `allowHttp: true`.
+ *
+ * The resolver does NOT cache. The `SnapshotVerifier` that uses it
+ * caches by operator DID for the lifetime of a snapshot, which is
+ * sufficient for v0 — operators don't rotate keys mid-fetch.
+ */
+export interface DidWebResolverConfig {
+  /** Test-only escape hatch to allow `http://` for did:web URLs (e.g. localhost). */
+  allowHttp?: boolean;
+
+  /** Override the global `fetch` for tests. */
+  fetch?: typeof globalThis.fetch;
+}
+
+export class DidWebResolver {
+  constructor(private readonly config: DidWebResolverConfig = {}) {}
+
+  async resolve(did: string): Promise<DidDocument> {
+    const url = didWebToUrl(did, this.config.allowHttp ?? false);
+    const fetcher = this.config.fetch ?? globalThis.fetch;
+    const response = await fetcher(url, {
+      headers: { Accept: 'application/json' },
+    });
+    if (!response.ok) {
+      throw new Error(
+        `did:web resolution failed: ${response.status} ${response.statusText} for ${url}`,
+      );
+    }
+    const doc = (await response.json()) as DidDocument;
+    if (typeof doc?.id !== 'string') {
+      throw new Error(`did:web document missing or invalid "id" field`);
+    }
+    if (doc.id !== did) {
+      throw new Error(
+        `did:web document id mismatch: expected "${did}", got "${doc.id}"`,
+      );
+    }
+    return doc;
+  }
+}
+
+/**
+ * Translates a `did:web` URI to its HTTPS URL per the did-web spec.
+ * Exported for tests; production callers should go through the
+ * resolver.
+ */
+export function didWebToUrl(did: string, allowHttp: boolean): string {
+  if (!did.startsWith('did:web:')) {
+    throw new Error(`not a did:web URI: ${did}`);
+  }
+  const segments = did.slice('did:web:'.length).split(':');
+  if (segments.length === 0 || segments[0] === '') {
+    throw new Error(`did:web URI is missing a host: ${did}`);
+  }
+  const host = decodeURIComponent(segments[0]);
+  const path =
+    segments.length === 1
+      ? '/.well-known/did.json'
+      : '/' + segments.slice(1).map(decodeURIComponent).join('/') + '/did.json';
+
+  // For localhost (test environments), allow http when explicitly opted
+  // in. Any other host MUST be https.
+  const protocol = (() => {
+    if (!allowHttp) return 'https';
+    if (host === 'localhost' || host.startsWith('127.0.0.1')) return 'http';
+    if (host.endsWith(':localhost')) return 'http';
+    return 'https';
+  })();
+  return `${protocol}://${host}${path}`;
+}

--- a/packages/o-gateway-registry/src/did/did-web-snapshot-verifier.ts
+++ b/packages/o-gateway-registry/src/did/did-web-snapshot-verifier.ts
@@ -1,0 +1,167 @@
+import { createPublicKey, verify as cryptoVerify } from 'node:crypto';
+import {
+  GatewayRegistryEntry,
+  RegistrySnapshot,
+} from '../interfaces/index.js';
+import { SnapshotVerifier } from '../registry/snapshot-verifier.js';
+import {
+  entrySigningPayload,
+  snapshotSigningPayload,
+} from '../canonical/index.js';
+import { DidDocument, VerificationMethod } from './did-document.js';
+import { decodeEd25519PublicKey } from './multibase.js';
+import { DidWebResolver, DidWebResolverConfig } from './did-web-resolver.js';
+
+/**
+ * Real signature verifier — replaces `AlwaysAcceptVerifier` from the
+ * skeleton PR. Resolves operator and maintainer DIDs via `did:web`,
+ * extracts Ed25519 verification keys, and verifies signatures over
+ * canonicalized payloads.
+ *
+ * Caching: the verifier memoizes resolved DID documents for the
+ * lifetime of the instance. Each operator DID is fetched at most
+ * once. Resolvers SHOULD construct a new verifier per snapshot
+ * lifecycle if they want to pick up key rotations.
+ *
+ * Failure modes:
+ *   - DID document fetch fails / 404 / non-https → throws
+ *   - DID document missing the requested key → throws
+ *   - Multibase decode / multicodec header wrong → throws
+ *   - Signature does not verify → throws
+ *
+ * The resolver upstream catches per-entry throws and drops the entry
+ * (X.509 chain semantics — one bad operator doesn't poison the
+ * snapshot). Snapshot-level failures propagate.
+ */
+export class DidWebSnapshotVerifier implements SnapshotVerifier {
+  private readonly resolver: DidWebResolver;
+  private readonly cache = new Map<string, Promise<DidDocument>>();
+
+  constructor(config: DidWebResolverConfig = {}) {
+    this.resolver = new DidWebResolver(config);
+  }
+
+  async verifySnapshot(
+    snapshot: RegistrySnapshot,
+    expectedMaintainerDid: string,
+  ): Promise<void> {
+    const sig = snapshot.maintainerSignature;
+    if (!sig) {
+      throw new Error('snapshot is missing maintainerSignature');
+    }
+    if (sig.maintainerDid !== expectedMaintainerDid) {
+      throw new Error(
+        `snapshot maintainer DID mismatch: expected "${expectedMaintainerDid}", got "${sig.maintainerDid}"`,
+      );
+    }
+    if (sig.algorithm !== 'Ed25519') {
+      throw new Error(`unsupported snapshot signature algorithm: ${sig.algorithm}`);
+    }
+    const doc = await this.resolveDid(sig.maintainerDid);
+    const key = findVerificationKey(doc, sig.keyId);
+    const payload = snapshotSigningPayload(snapshot);
+    const ok = ed25519Verify(key, payload, sig.value);
+    if (!ok) {
+      throw new Error('snapshot maintainer signature did not verify');
+    }
+  }
+
+  async verifyEntry(entry: GatewayRegistryEntry): Promise<void> {
+    if (!entry.signature) {
+      throw new Error(`entry "${entry.name}" is missing a signature`);
+    }
+    if (entry.signature.algorithm !== 'Ed25519') {
+      throw new Error(
+        `entry "${entry.name}" signature algorithm "${entry.signature.algorithm}" is not supported`,
+      );
+    }
+    const doc = await this.resolveDid(entry.operatorDid);
+    const key = findVerificationKey(doc, entry.signature.keyId);
+    const payload = entrySigningPayload(entry);
+    const ok = ed25519Verify(key, payload, entry.signature.value);
+    if (!ok) {
+      throw new Error(`entry "${entry.name}" signature did not verify`);
+    }
+  }
+
+  private resolveDid(did: string): Promise<DidDocument> {
+    const cached = this.cache.get(did);
+    if (cached) return cached;
+    const promise = this.resolver.resolve(did).catch((err) => {
+      // On failure, evict so a retry can re-fetch.
+      this.cache.delete(did);
+      throw err;
+    });
+    this.cache.set(did, promise);
+    return promise;
+  }
+}
+
+function findVerificationKey(
+  doc: DidDocument,
+  keyId: string,
+): Uint8Array {
+  const methods = doc.verificationMethod ?? [];
+  const method = methods.find((m) => m.id === keyId);
+  if (!method) {
+    throw new Error(`DID document does not contain key "${keyId}"`);
+  }
+  return extractEd25519Key(method);
+}
+
+function extractEd25519Key(method: VerificationMethod): Uint8Array {
+  if (method.type !== 'Ed25519VerificationKey2020') {
+    throw new Error(
+      `unsupported verification method type: ${method.type} (v0 requires Ed25519VerificationKey2020)`,
+    );
+  }
+  if (!method.publicKeyMultibase) {
+    throw new Error(
+      `verification method "${method.id}" missing publicKeyMultibase`,
+    );
+  }
+  return decodeEd25519PublicKey(method.publicKeyMultibase);
+}
+
+function ed25519Verify(
+  publicKey: Uint8Array,
+  message: Uint8Array,
+  signatureBase64: string,
+): boolean {
+  // Wrap the raw 32-byte Ed25519 public key in a SubjectPublicKeyInfo
+  // DER envelope so node:crypto's createPublicKey accepts it.
+  const spki = ed25519RawToSpki(publicKey);
+  const keyObject = createPublicKey({
+    key: spki,
+    format: 'der',
+    type: 'spki',
+  });
+  const signature = Buffer.from(signatureBase64, 'base64');
+  return cryptoVerify(null, message, keyObject, signature);
+}
+
+/**
+ * Wraps a raw 32-byte Ed25519 public key in the SubjectPublicKeyInfo
+ * DER structure (RFC 8410 §4):
+ *
+ *   SEQUENCE {
+ *     SEQUENCE { OID 1.3.101.112 }   -- id-Ed25519
+ *     BIT STRING (no unused bits) { <32-byte raw key> }
+ *   }
+ *
+ * The resulting envelope is exactly 44 bytes for any Ed25519 key, so
+ * we hand-build it rather than pulling an ASN.1 library. The 12-byte
+ * prefix is the OID + length headers; the rest is the raw key.
+ */
+function ed25519RawToSpki(rawKey: Uint8Array): Buffer {
+  if (rawKey.length !== 32) {
+    throw new Error(`expected 32-byte Ed25519 key, got ${rawKey.length}`);
+  }
+  const prefix = Buffer.from([
+    0x30, 0x2a, // SEQUENCE, length 42
+    0x30, 0x05, // SEQUENCE, length 5 (algorithm identifier)
+    0x06, 0x03, 0x2b, 0x65, 0x70, // OID 1.3.101.112 (id-Ed25519)
+    0x03, 0x21, 0x00, // BIT STRING, length 33, 0 unused bits
+  ]);
+  return Buffer.concat([prefix, Buffer.from(rawKey)]);
+}

--- a/packages/o-gateway-registry/src/did/index.ts
+++ b/packages/o-gateway-registry/src/did/index.ts
@@ -1,0 +1,7 @@
+export * from './did-document.js';
+export * from './did-web-resolver.js';
+export * from './did-web-snapshot-verifier.js';
+export {
+  decodeEd25519PublicKey,
+  encodeEd25519PublicKey,
+} from './multibase.js';

--- a/packages/o-gateway-registry/src/did/multibase.ts
+++ b/packages/o-gateway-registry/src/did/multibase.ts
@@ -1,0 +1,126 @@
+/**
+ * base58btc codec for the multibase prefix `z`.
+ *
+ * `Ed25519VerificationKey2020` per the DID Core spec encodes the public
+ * key as multibase base58btc (`z` prefix) of the multicodec envelope
+ * (`0xed01` for Ed25519-pub) followed by the 32-byte raw key. We strip
+ * the prefix, decode base58btc, validate the multicodec header, and
+ * return the 32-byte key.
+ *
+ * Implementation note: we inline a small, well-tested base58btc
+ * algorithm (the standard "iterative big-int" variant used by
+ * Bitcoin Core, bs58, and multiformats) rather than pulling a
+ * dependency. This is the only multibase encoding v0 needs and the
+ * codec is ~50 lines. v1 can reach for `multiformats` if more
+ * encodings show up.
+ */
+const BASE58_ALPHABET =
+  '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+const BASE58_INDEX: Record<string, number> = (() => {
+  const map: Record<string, number> = {};
+  for (let i = 0; i < BASE58_ALPHABET.length; i += 1) {
+    map[BASE58_ALPHABET[i]] = i;
+  }
+  return map;
+})();
+
+export function base58Encode(bytes: Uint8Array): string {
+  if (bytes.length === 0) return '';
+  // Count leading zero bytes — each becomes a leading '1' in the output.
+  let zeros = 0;
+  while (zeros < bytes.length && bytes[zeros] === 0) zeros += 1;
+
+  // Working buffer, treated as a big-endian big integer in base 58.
+  // size = ceil(input * log(256) / log(58)) ≈ ceil(input * 138 / 100).
+  const digits: number[] = [];
+  for (let i = zeros; i < bytes.length; i += 1) {
+    let carry = bytes[i];
+    for (let j = 0; j < digits.length; j += 1) {
+      const x = digits[j] * 256 + carry;
+      digits[j] = x % 58;
+      carry = Math.floor(x / 58);
+    }
+    while (carry > 0) {
+      digits.push(carry % 58);
+      carry = Math.floor(carry / 58);
+    }
+  }
+  let out = '';
+  for (let i = 0; i < zeros; i += 1) out += '1';
+  for (let i = digits.length - 1; i >= 0; i -= 1) {
+    out += BASE58_ALPHABET[digits[i]];
+  }
+  return out;
+}
+
+export function base58Decode(s: string): Uint8Array {
+  if (s.length === 0) return new Uint8Array(0);
+  // Count leading '1' chars — each represents a leading zero byte.
+  let zeros = 0;
+  while (zeros < s.length && s[zeros] === '1') zeros += 1;
+
+  const bytes: number[] = [];
+  for (let i = zeros; i < s.length; i += 1) {
+    const ch = s[i];
+    const value = BASE58_INDEX[ch];
+    if (value === undefined) {
+      throw new Error(`base58: invalid character "${ch}"`);
+    }
+    let carry = value;
+    for (let j = 0; j < bytes.length; j += 1) {
+      const x = bytes[j] * 58 + carry;
+      bytes[j] = x & 0xff;
+      carry = x >>> 8;
+    }
+    while (carry > 0) {
+      bytes.push(carry & 0xff);
+      carry = carry >>> 8;
+    }
+  }
+  // bytes is little-endian; reverse it and prepend the leading-zero count.
+  const out = new Uint8Array(zeros + bytes.length);
+  for (let i = 0; i < bytes.length; i += 1) {
+    out[zeros + i] = bytes[bytes.length - 1 - i];
+  }
+  return out;
+}
+
+/**
+ * Decodes a `publicKeyMultibase` string for an Ed25519 key into the
+ * 32-byte raw public key. Throws if the prefix, multicodec header, or
+ * length is wrong.
+ *
+ * Multibase: `z` prefix → base58btc payload.
+ * Multicodec: `0xed 0x01` → Ed25519-pub.
+ * Then 32 bytes of public key.
+ */
+export function decodeEd25519PublicKey(multibase: string): Uint8Array {
+  if (multibase.length === 0 || multibase[0] !== 'z') {
+    throw new Error(
+      `expected multibase base58btc prefix "z", got "${multibase[0]}"`,
+    );
+  }
+  const decoded = base58Decode(multibase.slice(1));
+  if (decoded.length !== 34 || decoded[0] !== 0xed || decoded[1] !== 0x01) {
+    throw new Error(
+      'multibase payload is not Ed25519-pub multicodec (expected 0xed01)',
+    );
+  }
+  return decoded.subarray(2);
+}
+
+/**
+ * Encodes a 32-byte raw Ed25519 public key as `Ed25519VerificationKey2020`
+ * `publicKeyMultibase` — base58btc with the `z` prefix and the
+ * Ed25519-pub multicodec header (`0xed 0x01`).
+ */
+export function encodeEd25519PublicKey(rawKey: Uint8Array): string {
+  if (rawKey.length !== 32) {
+    throw new Error(`expected 32-byte Ed25519 key, got ${rawKey.length}`);
+  }
+  const wrapped = new Uint8Array(34);
+  wrapped[0] = 0xed;
+  wrapped[1] = 0x01;
+  wrapped.set(rawKey, 2);
+  return 'z' + base58Encode(wrapped);
+}

--- a/packages/o-gateway-registry/src/index.ts
+++ b/packages/o-gateway-registry/src/index.ts
@@ -1,2 +1,4 @@
 export * from './interfaces/index.js';
 export * from './registry/index.js';
+export * from './canonical/index.js';
+export * from './did/index.js';

--- a/packages/o-gateway-registry/src/registry/gateway-registry-resolver.ts
+++ b/packages/o-gateway-registry/src/registry/gateway-registry-resolver.ts
@@ -16,10 +16,8 @@ import {
   HttpsSnapshotFetcher,
   SnapshotFetcher,
 } from './snapshot-fetcher.js';
-import {
-  AlwaysAcceptVerifier,
-  SnapshotVerifier,
-} from './snapshot-verifier.js';
+import { SnapshotVerifier } from './snapshot-verifier.js';
+import { DidWebSnapshotVerifier } from '../did/did-web-snapshot-verifier.js';
 import { isReservedGatewayName } from './reserved-names.js';
 
 /**
@@ -54,7 +52,7 @@ export class GatewayRegistryResolver extends oAddressResolver {
     address: oAddress,
     private readonly config: GatewayRegistryResolverConfig,
     private readonly fetcher: SnapshotFetcher = new HttpsSnapshotFetcher(),
-    private readonly verifier: SnapshotVerifier = new AlwaysAcceptVerifier(),
+    private readonly verifier: SnapshotVerifier = new DidWebSnapshotVerifier(),
   ) {
     super(address);
   }

--- a/packages/o-gateway-registry/test/did/canonicalize.test.ts
+++ b/packages/o-gateway-registry/test/did/canonicalize.test.ts
@@ -46,8 +46,8 @@ describe('canonicalize', () => {
   });
 
   test('two reorderings produce identical output', () => {
-    const a = { meta: 'x', name: 'y', transports: ['/a', '/b'] };
-    const b = { transports: ['/a', '/b'], name: 'y', meta: 'x' };
+    const a = { extra: 'x', name: 'y', transports: ['/a', '/b'] };
+    const b = { transports: ['/a', '/b'], name: 'y', extra: 'x' };
     expect(canonicalize(a)).toBe(canonicalize(b));
   });
 });

--- a/packages/o-gateway-registry/test/did/canonicalize.test.ts
+++ b/packages/o-gateway-registry/test/did/canonicalize.test.ts
@@ -1,0 +1,53 @@
+import { canonicalize } from '../../src/canonical/canonicalize.js';
+
+describe('canonicalize', () => {
+  test('object keys are sorted lexicographically', () => {
+    expect(canonicalize({ b: 1, a: 2 })).toBe('{"a":2,"b":1}');
+  });
+
+  test('nested objects sort recursively', () => {
+    expect(canonicalize({ z: { y: 1, x: 2 }, a: 3 })).toBe(
+      '{"a":3,"z":{"x":2,"y":1}}',
+    );
+  });
+
+  test('arrays preserve order', () => {
+    expect(canonicalize([3, 1, 2])).toBe('[3,1,2]');
+  });
+
+  test('strings are JSON-escaped', () => {
+    expect(canonicalize('hello "world"')).toBe('"hello \\"world\\""');
+    expect(canonicalize('line\nbreak')).toBe('"line\\nbreak"');
+  });
+
+  test('null/true/false are literal', () => {
+    expect(canonicalize(null)).toBe('null');
+    expect(canonicalize(true)).toBe('true');
+    expect(canonicalize(false)).toBe('false');
+  });
+
+  test('numbers serialize to their string form', () => {
+    expect(canonicalize(0)).toBe('0');
+    expect(canonicalize(42)).toBe('42');
+    expect(canonicalize(-1)).toBe('-1');
+  });
+
+  test('non-finite numbers throw', () => {
+    expect(() => canonicalize(Infinity)).toThrow(/non-finite/);
+    expect(() => canonicalize(NaN)).toThrow(/non-finite/);
+  });
+
+  test('undefined keys are dropped', () => {
+    expect(canonicalize({ a: 1, b: undefined })).toBe('{"a":1}');
+  });
+
+  test('undefined value at the top level throws', () => {
+    expect(() => canonicalize(undefined)).toThrow();
+  });
+
+  test('two reorderings produce identical output', () => {
+    const a = { meta: 'x', name: 'y', transports: ['/a', '/b'] };
+    const b = { transports: ['/a', '/b'], name: 'y', meta: 'x' };
+    expect(canonicalize(a)).toBe(canonicalize(b));
+  });
+});

--- a/packages/o-gateway-registry/test/did/did-web-resolver.test.ts
+++ b/packages/o-gateway-registry/test/did/did-web-resolver.test.ts
@@ -1,0 +1,79 @@
+import {
+  DidWebResolver,
+  didWebToUrl,
+} from '../../src/did/did-web-resolver.js';
+
+describe('didWebToUrl', () => {
+  test('bare host → /.well-known/did.json', () => {
+    expect(didWebToUrl('did:web:example.com', false)).toBe(
+      'https://example.com/.well-known/did.json',
+    );
+  });
+
+  test('host + path → /<path>/did.json', () => {
+    expect(didWebToUrl('did:web:example.com:user:alice', false)).toBe(
+      'https://example.com/user/alice/did.json',
+    );
+  });
+
+  test('percent-encoded port survives translation', () => {
+    expect(didWebToUrl('did:web:example.com%3A8443', false)).toBe(
+      'https://example.com:8443/.well-known/did.json',
+    );
+  });
+
+  test('refuses non-did:web input', () => {
+    expect(() => didWebToUrl('did:plc:abc', false)).toThrow(/not a did:web/);
+  });
+
+  test('localhost gets http when allowHttp is true (test mode)', () => {
+    expect(didWebToUrl('did:web:localhost', true)).toBe(
+      'http://localhost/.well-known/did.json',
+    );
+  });
+
+  test('localhost stays https when allowHttp is false', () => {
+    expect(didWebToUrl('did:web:localhost', false)).toBe(
+      'https://localhost/.well-known/did.json',
+    );
+  });
+});
+
+describe('DidWebResolver', () => {
+  test('fetches and returns the DID document', async () => {
+    const doc = {
+      id: 'did:web:example.com',
+      verificationMethod: [],
+    };
+    const resolver = new DidWebResolver({
+      fetch: async () =>
+        new Response(JSON.stringify(doc), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+    });
+    const result = await resolver.resolve('did:web:example.com');
+    expect(result.id).toBe('did:web:example.com');
+  });
+
+  test('throws if the response is non-2xx', async () => {
+    const resolver = new DidWebResolver({
+      fetch: async () => new Response('not found', { status: 404 }),
+    });
+    await expect(resolver.resolve('did:web:example.com')).rejects.toThrow(
+      /404/,
+    );
+  });
+
+  test('throws if the document id does not match the requested DID', async () => {
+    const resolver = new DidWebResolver({
+      fetch: async () =>
+        new Response(JSON.stringify({ id: 'did:web:other.example.com' }), {
+          status: 200,
+        }),
+    });
+    await expect(resolver.resolve('did:web:example.com')).rejects.toThrow(
+      /document id mismatch/,
+    );
+  });
+});

--- a/packages/o-gateway-registry/test/did/did-web-snapshot-verifier.test.ts
+++ b/packages/o-gateway-registry/test/did/did-web-snapshot-verifier.test.ts
@@ -21,7 +21,7 @@ function newTestSetup(): TestSetup {
   const maintainerDid = 'did:web:registry.olane.network';
   const maintainerKey = generateTestKey();
   const maintainerKeyId = `${maintainerDid}#key-1`;
-  const operatorDid = 'did:web:meta.example.com';
+  const operatorDid = 'did:web:copass.example.com';
   const operatorKey = generateTestKey();
   const operatorKeyId = `${operatorDid}#key-1`;
 
@@ -31,7 +31,7 @@ function newTestSetup(): TestSetup {
       maintainerKeyId,
       maintainerKey,
     ),
-    'https://meta.example.com/.well-known/did.json': makeDidDocument(
+    'https://copass.example.com/.well-known/did.json': makeDidDocument(
       operatorDid,
       operatorKeyId,
       operatorKey,
@@ -226,7 +226,7 @@ describe('DidWebSnapshotVerifier — verifyEntry', () => {
 
     const entryA = signEntry(
       makeEntry({
-        name: 'meta',
+        name: 'copass',
         operatorDid: setup.operatorDid,
         signature: {
           keyId: `${setup.operatorDid}#key-1`,
@@ -238,7 +238,7 @@ describe('DidWebSnapshotVerifier — verifyEntry', () => {
     );
     const entryB = signEntry(
       makeEntry({
-        name: 'meta-test',
+        name: 'copass-test',
         operatorDid: setup.operatorDid,
         signature: {
           keyId: `${setup.operatorDid}#key-1`,

--- a/packages/o-gateway-registry/test/did/did-web-snapshot-verifier.test.ts
+++ b/packages/o-gateway-registry/test/did/did-web-snapshot-verifier.test.ts
@@ -1,0 +1,257 @@
+import { DidWebSnapshotVerifier } from '../../src/did/did-web-snapshot-verifier.js';
+import { GatewayRegistryEntry } from '../../src/interfaces/index.js';
+import { makeEntry, makeSnapshot } from '../fixtures/snapshot.js';
+import {
+  TestKey,
+  generateTestKey,
+  makeDidDocument,
+  signEntry,
+  signSnapshot,
+} from './test-keys.js';
+
+interface TestSetup {
+  maintainerDid: string;
+  maintainerKey: TestKey;
+  operatorDid: string;
+  operatorKey: TestKey;
+  fetcher: typeof globalThis.fetch;
+}
+
+function newTestSetup(): TestSetup {
+  const maintainerDid = 'did:web:registry.olane.network';
+  const maintainerKey = generateTestKey();
+  const maintainerKeyId = `${maintainerDid}#key-1`;
+  const operatorDid = 'did:web:meta.example.com';
+  const operatorKey = generateTestKey();
+  const operatorKeyId = `${operatorDid}#key-1`;
+
+  const docs: Record<string, unknown> = {
+    'https://registry.olane.network/.well-known/did.json': makeDidDocument(
+      maintainerDid,
+      maintainerKeyId,
+      maintainerKey,
+    ),
+    'https://meta.example.com/.well-known/did.json': makeDidDocument(
+      operatorDid,
+      operatorKeyId,
+      operatorKey,
+    ),
+  };
+
+  const fetcher: typeof globalThis.fetch = async (input) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    const doc = docs[url];
+    if (!doc) {
+      return new Response('not found', { status: 404 });
+    }
+    return new Response(JSON.stringify(doc), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  };
+
+  return { maintainerDid, maintainerKey, operatorDid, operatorKey, fetcher };
+}
+
+describe('DidWebSnapshotVerifier — verifySnapshot', () => {
+  test('accepts a correctly-signed snapshot', async () => {
+    const setup = newTestSetup();
+    const snapshot = signSnapshot(
+      makeSnapshot([], {
+        maintainerSignature: {
+          maintainerDid: setup.maintainerDid,
+          keyId: `${setup.maintainerDid}#key-1`,
+          algorithm: 'Ed25519',
+          value: '',
+        },
+      }),
+      setup.maintainerKey,
+    );
+    const verifier = new DidWebSnapshotVerifier({ fetch: setup.fetcher });
+
+    await expect(
+      verifier.verifySnapshot(snapshot, setup.maintainerDid),
+    ).resolves.toBeUndefined();
+  });
+
+  test('rejects a snapshot whose maintainer DID does not match config', async () => {
+    const setup = newTestSetup();
+    const snapshot = signSnapshot(
+      makeSnapshot([], {
+        maintainerSignature: {
+          maintainerDid: setup.maintainerDid,
+          keyId: `${setup.maintainerDid}#key-1`,
+          algorithm: 'Ed25519',
+          value: '',
+        },
+      }),
+      setup.maintainerKey,
+    );
+    const verifier = new DidWebSnapshotVerifier({ fetch: setup.fetcher });
+
+    await expect(
+      verifier.verifySnapshot(snapshot, 'did:web:other.example.com'),
+    ).rejects.toThrow(/maintainer DID mismatch/);
+  });
+
+  test('rejects a snapshot signed by the wrong key', async () => {
+    const setup = newTestSetup();
+    const wrongKey = generateTestKey();
+    const snapshot = signSnapshot(
+      makeSnapshot([], {
+        maintainerSignature: {
+          maintainerDid: setup.maintainerDid,
+          keyId: `${setup.maintainerDid}#key-1`,
+          algorithm: 'Ed25519',
+          value: '',
+        },
+      }),
+      wrongKey,
+    );
+    const verifier = new DidWebSnapshotVerifier({ fetch: setup.fetcher });
+
+    await expect(
+      verifier.verifySnapshot(snapshot, setup.maintainerDid),
+    ).rejects.toThrow(/did not verify/);
+  });
+
+  test('rejects a snapshot whose payload was tampered with after signing', async () => {
+    const setup = newTestSetup();
+    const snapshot = signSnapshot(
+      makeSnapshot([], {
+        maintainerSignature: {
+          maintainerDid: setup.maintainerDid,
+          keyId: `${setup.maintainerDid}#key-1`,
+          algorithm: 'Ed25519',
+          value: '',
+        },
+      }),
+      setup.maintainerKey,
+    );
+    const tampered = { ...snapshot, pinnedCommit: 'tampered-commit' };
+    const verifier = new DidWebSnapshotVerifier({ fetch: setup.fetcher });
+
+    await expect(
+      verifier.verifySnapshot(tampered, setup.maintainerDid),
+    ).rejects.toThrow(/did not verify/);
+  });
+});
+
+describe('DidWebSnapshotVerifier — verifyEntry', () => {
+  test('accepts a correctly-signed entry', async () => {
+    const setup = newTestSetup();
+    const entry: GatewayRegistryEntry = signEntry(
+      makeEntry({
+        operatorDid: setup.operatorDid,
+        signature: {
+          keyId: `${setup.operatorDid}#key-1`,
+          algorithm: 'Ed25519',
+          value: '',
+        },
+      }),
+      setup.operatorKey,
+    );
+    const verifier = new DidWebSnapshotVerifier({ fetch: setup.fetcher });
+
+    await expect(verifier.verifyEntry(entry)).resolves.toBeUndefined();
+  });
+
+  test('rejects an entry signed by the wrong key', async () => {
+    const setup = newTestSetup();
+    const wrongKey = generateTestKey();
+    const entry = signEntry(
+      makeEntry({
+        operatorDid: setup.operatorDid,
+        signature: {
+          keyId: `${setup.operatorDid}#key-1`,
+          algorithm: 'Ed25519',
+          value: '',
+        },
+      }),
+      wrongKey,
+    );
+    const verifier = new DidWebSnapshotVerifier({ fetch: setup.fetcher });
+
+    await expect(verifier.verifyEntry(entry)).rejects.toThrow(
+      /did not verify/,
+    );
+  });
+
+  test('rejects an entry whose did:web document is unreachable', async () => {
+    const setup = newTestSetup();
+    const entry = signEntry(
+      makeEntry({
+        operatorDid: 'did:web:gone.example.com',
+        signature: {
+          keyId: 'did:web:gone.example.com#key-1',
+          algorithm: 'Ed25519',
+          value: '',
+        },
+      }),
+      setup.operatorKey,
+    );
+    const verifier = new DidWebSnapshotVerifier({ fetch: setup.fetcher });
+
+    await expect(verifier.verifyEntry(entry)).rejects.toThrow(/404/);
+  });
+
+  test('rejects an entry whose key is missing from the DID document', async () => {
+    const setup = newTestSetup();
+    const entry = signEntry(
+      makeEntry({
+        operatorDid: setup.operatorDid,
+        signature: {
+          keyId: `${setup.operatorDid}#key-2`, // not in DID document
+          algorithm: 'Ed25519',
+          value: '',
+        },
+      }),
+      setup.operatorKey,
+    );
+    const verifier = new DidWebSnapshotVerifier({ fetch: setup.fetcher });
+
+    await expect(verifier.verifyEntry(entry)).rejects.toThrow(
+      /does not contain key/,
+    );
+  });
+
+  test('caches DID documents — second verifyEntry against same DID does not re-fetch', async () => {
+    const setup = newTestSetup();
+    let fetchCount = 0;
+    const countingFetcher: typeof globalThis.fetch = async (input) => {
+      fetchCount += 1;
+      return setup.fetcher(input);
+    };
+    const verifier = new DidWebSnapshotVerifier({ fetch: countingFetcher });
+
+    const entryA = signEntry(
+      makeEntry({
+        name: 'meta',
+        operatorDid: setup.operatorDid,
+        signature: {
+          keyId: `${setup.operatorDid}#key-1`,
+          algorithm: 'Ed25519',
+          value: '',
+        },
+      }),
+      setup.operatorKey,
+    );
+    const entryB = signEntry(
+      makeEntry({
+        name: 'meta-test',
+        operatorDid: setup.operatorDid,
+        signature: {
+          keyId: `${setup.operatorDid}#key-1`,
+          algorithm: 'Ed25519',
+          value: '',
+        },
+      }),
+      setup.operatorKey,
+    );
+
+    await verifier.verifyEntry(entryA);
+    await verifier.verifyEntry(entryB);
+
+    expect(fetchCount).toBe(1);
+  });
+});

--- a/packages/o-gateway-registry/test/did/multibase.test.ts
+++ b/packages/o-gateway-registry/test/did/multibase.test.ts
@@ -1,0 +1,27 @@
+import { decodeEd25519PublicKey } from '../../src/did/multibase.js';
+import { generateTestKey } from './test-keys.js';
+
+describe('decodeEd25519PublicKey', () => {
+  test('round-trips a freshly-generated Ed25519 key', () => {
+    const key = generateTestKey();
+    const decoded = decodeEd25519PublicKey(key.publicKeyMultibase);
+    expect(decoded.length).toBe(32);
+    expect(Buffer.from(decoded).equals(Buffer.from(key.rawPublic))).toBe(true);
+  });
+
+  test('rejects a multibase value without the "z" prefix', () => {
+    expect(() => decodeEd25519PublicKey('xABC')).toThrow(/multibase base58btc prefix/);
+  });
+
+  test('rejects a multibase value whose multicodec header is wrong', () => {
+    // base58btc-encode something with a non-Ed25519 multicodec prefix.
+    // Here we just feed an obviously-invalid string.
+    expect(() => decodeEd25519PublicKey('z11111')).toThrow(
+      /Ed25519-pub multicodec/,
+    );
+  });
+
+  test('rejects empty input', () => {
+    expect(() => decodeEd25519PublicKey('')).toThrow(/multibase base58btc prefix/);
+  });
+});

--- a/packages/o-gateway-registry/test/did/test-keys.ts
+++ b/packages/o-gateway-registry/test/did/test-keys.ts
@@ -1,0 +1,117 @@
+import {
+  generateKeyPairSync,
+  KeyObject,
+  sign as cryptoSign,
+} from 'node:crypto';
+import {
+  GatewayRegistryEntry,
+  RegistrySnapshot,
+} from '../../src/interfaces/index.js';
+import {
+  entrySigningPayload,
+  snapshotSigningPayload,
+} from '../../src/canonical/signing-payload.js';
+import { DidDocument } from '../../src/did/did-document.js';
+import { encodeEd25519PublicKey } from '../../src/did/multibase.js';
+
+/**
+ * Generates an Ed25519 key pair and returns the components a test
+ * fixture needs: the key objects, the raw 32-byte public key, the
+ * `Ed25519VerificationKey2020` `publicKeyMultibase` value, and a
+ * helper that signs arbitrary canonicalized payloads.
+ */
+export function generateTestKey(): TestKey {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  const rawPublic = extractRawEd25519Public(publicKey);
+  const publicKeyMultibase = encodeEd25519PublicKey(rawPublic);
+  return {
+    publicKey,
+    privateKey,
+    rawPublic,
+    publicKeyMultibase,
+    sign(payload: Uint8Array): string {
+      const buf = Buffer.from(
+        payload.buffer,
+        payload.byteOffset,
+        payload.byteLength,
+      );
+      const sig = cryptoSign(null, buf, privateKey);
+      return sig.toString('base64');
+    },
+  };
+}
+
+export interface TestKey {
+  publicKey: KeyObject;
+  privateKey: KeyObject;
+  rawPublic: Uint8Array;
+  publicKeyMultibase: string;
+  sign(payload: Uint8Array): string;
+}
+
+export function makeDidDocument(
+  did: string,
+  keyId: string,
+  key: TestKey,
+): DidDocument {
+  return {
+    '@context': [
+      'https://www.w3.org/ns/did/v1',
+      'https://w3id.org/security/suites/ed25519-2020/v1',
+    ],
+    id: did,
+    verificationMethod: [
+      {
+        id: keyId,
+        type: 'Ed25519VerificationKey2020',
+        controller: did,
+        publicKeyMultibase: key.publicKeyMultibase,
+      },
+    ],
+    assertionMethod: [keyId],
+  };
+}
+
+export function signEntry(
+  entry: GatewayRegistryEntry,
+  key: TestKey,
+): GatewayRegistryEntry {
+  const payload = entrySigningPayload({ ...entry, signature: undefined as never });
+  return {
+    ...entry,
+    signature: {
+      keyId: entry.signature.keyId,
+      algorithm: 'Ed25519',
+      value: key.sign(payload),
+    },
+  };
+}
+
+export function signSnapshot(
+  snapshot: RegistrySnapshot,
+  key: TestKey,
+): RegistrySnapshot {
+  const payload = snapshotSigningPayload({
+    ...snapshot,
+    maintainerSignature: undefined as never,
+  });
+  return {
+    ...snapshot,
+    maintainerSignature: {
+      maintainerDid: snapshot.maintainerSignature.maintainerDid,
+      keyId: snapshot.maintainerSignature.keyId,
+      algorithm: 'Ed25519',
+      value: key.sign(payload),
+    },
+  };
+}
+
+function extractRawEd25519Public(key: KeyObject): Uint8Array {
+  // Export as raw SPKI DER and strip the 12-byte Ed25519 SPKI prefix.
+  const der = key.export({ type: 'spki', format: 'der' });
+  if (der.length !== 44) {
+    throw new Error(`unexpected SPKI length: ${der.length}`);
+  }
+  return new Uint8Array(der.subarray(12));
+}
+

--- a/packages/o-gateway-registry/test/fixtures/snapshot.ts
+++ b/packages/o-gateway-registry/test/fixtures/snapshot.ts
@@ -9,16 +9,16 @@ export function makeEntry(
   overrides: Partial<GatewayRegistryEntry> = {},
 ): GatewayRegistryEntry {
   return {
-    name: 'meta',
-    operatorDid: 'did:web:meta.example.com',
-    transports: ['/dns4/leader.meta.example.com/tcp/4000/tls/ws'],
-    description: 'Meta operator gateway (test fixture)',
+    name: 'copass',
+    operatorDid: 'did:web:copass.example.com',
+    transports: ['/dns4/leader.copass.example.com/tcp/4000/tls/ws'],
+    description: 'Copass operator gateway (test fixture)',
     logo: '',
-    website: 'https://meta.example.com',
+    website: 'https://copass.example.com',
     defaultCapabilityClass: 'side-effecting',
     publishedAt: '2026-05-09T00:00:00Z',
     signature: {
-      keyId: 'did:web:meta.example.com#key-1',
+      keyId: 'did:web:copass.example.com#key-1',
       algorithm: 'Ed25519',
       value: 'AAAA',
     },

--- a/packages/o-gateway-registry/test/gateway-registry-resolver.test.ts
+++ b/packages/o-gateway-registry/test/gateway-registry-resolver.test.ts
@@ -37,7 +37,7 @@ function makeRequest(uri: string) {
 
 describe('GatewayRegistryResolver — load() lifecycle', () => {
   test('load() fetches the snapshot once and verifies it', async () => {
-    const snapshot = makeSnapshot([makeEntry({ name: 'meta' })]);
+    const snapshot = makeSnapshot([makeEntry({ name: 'copass' })]);
     const verifyCalls: Array<{ snap: RegistrySnapshot; did: string }> = [];
     const verifier: SnapshotVerifier = {
       async verifySnapshot(snap, did) {
@@ -88,19 +88,19 @@ describe('GatewayRegistryResolver — load() lifecycle', () => {
 describe('GatewayRegistryResolver — resolve()', () => {
   test('routes to the gateway transport when first segment matches an entry', async () => {
     const entry = makeEntry({
-      name: 'meta',
-      transports: ['/dns4/leader.meta.example.com/tcp/4000/tls/ws'],
+      name: 'copass',
+      transports: ['/dns4/leader.copass.example.com/tcp/4000/tls/ws'],
     });
     const resolver = makeResolver(makeSnapshot([entry]));
 
     const result = await resolver.resolve(
-      makeRequest('o://meta/brendon/shell'),
+      makeRequest('o://copass/brendon/shell'),
     );
 
     expect(result.nextHopAddress.toString()).toBe('o://leader');
     const transports = result.nextHopAddress.transports.map((t) => t.value);
     expect(transports).toEqual([
-      '/dns4/leader.meta.example.com/tcp/4000/tls/ws',
+      '/dns4/leader.copass.example.com/tcp/4000/tls/ws',
     ]);
   });
 
@@ -133,25 +133,25 @@ describe('GatewayRegistryResolver — resolve()', () => {
   });
 
   test('drops entries that fail per-entry verification rather than throwing', async () => {
-    const entry = makeEntry({ name: 'meta' });
+    const entry = makeEntry({ name: 'copass' });
     const verifier: SnapshotVerifier = {
       async verifySnapshot() {
         // accept the snapshot
       },
       async verifyEntry(e: GatewayRegistryEntry) {
-        if (e.name === 'meta') throw new Error('forged entry');
+        if (e.name === 'copass') throw new Error('forged entry');
       },
     };
     const resolver = makeResolver(makeSnapshot([entry]), { verifier });
 
-    const req = makeRequest('o://meta/brendon');
+    const req = makeRequest('o://copass/brendon');
     const result = await resolver.resolve(req);
 
     expect(result.nextHopAddress).toBe(req.address);
   });
 
   test('lazy-loads the snapshot on first resolve when load() was not called', async () => {
-    const snapshot = makeSnapshot([makeEntry({ name: 'meta' })]);
+    const snapshot = makeSnapshot([makeEntry({ name: 'copass' })]);
     let fetchCount = 0;
     const fetcher: SnapshotFetcher = {
       async fetch() {
@@ -161,13 +161,13 @@ describe('GatewayRegistryResolver — resolve()', () => {
     };
     const resolver = makeResolver(snapshot, { fetcher });
 
-    await resolver.resolve(makeRequest('o://meta/x'));
+    await resolver.resolve(makeRequest('o://copass/x'));
 
     expect(fetchCount).toBe(1);
   });
 
   test('lookup() of a reserved name short-circuits and never fetches', async () => {
-    const snapshot = makeSnapshot([makeEntry({ name: 'meta' })]);
+    const snapshot = makeSnapshot([makeEntry({ name: 'copass' })]);
     let fetchCount = 0;
     const fetcher: SnapshotFetcher = {
       async fetch() {
@@ -197,7 +197,7 @@ describe('GatewayRegistryResolver — error posture', () => {
       fetcher,
     );
 
-    await expect(resolver.lookup('meta')).rejects.toThrow(/network down/);
+    await expect(resolver.lookup('copass')).rejects.toThrow(/network down/);
   });
 
   test('failClosed=false returns null when the fetch fails (test mode only)', async () => {
@@ -212,7 +212,7 @@ describe('GatewayRegistryResolver — error posture', () => {
       fetcher,
     );
 
-    const result = await resolver.lookup('meta');
+    const result = await resolver.lookup('copass');
     expect(result).toBeNull();
   });
 });

--- a/packages/o-gateway-registry/test/reserved-names.test.ts
+++ b/packages/o-gateway-registry/test/reserved-names.test.ts
@@ -29,14 +29,14 @@ describe('reserved gateway names', () => {
 
   test('a normal two-character name is not reserved', () => {
     expect(isReservedGatewayName('ab')).toBe(false);
-    expect(isReservedGatewayName('meta')).toBe(false);
+    expect(isReservedGatewayName('copass')).toBe(false);
     expect(isReservedGatewayName('your-grandma')).toBe(false);
   });
 });
 
 describe('validateGatewayName', () => {
   test('accepts the canonical examples from ADR 0025', () => {
-    expect(validateGatewayName('meta')).toBeNull();
+    expect(validateGatewayName('copass')).toBeNull();
     expect(validateGatewayName('your-grandma')).toBeNull();
     expect(validateGatewayName('acme-corp')).toBeNull();
   });
@@ -55,7 +55,7 @@ describe('validateGatewayName', () => {
   });
 
   test('rejects uppercase', () => {
-    expect(validateGatewayName('Meta')).toMatch(/lowercase/);
+    expect(validateGatewayName('Copass')).toMatch(/lowercase/);
   });
 
   test('rejects underscore (DNS-label compatibility)', () => {
@@ -63,11 +63,11 @@ describe('validateGatewayName', () => {
   });
 
   test('rejects leading hyphen', () => {
-    expect(validateGatewayName('-meta')).toMatch(/leading or trailing hyphen/);
+    expect(validateGatewayName('-copass')).toMatch(/leading or trailing hyphen/);
   });
 
   test('rejects trailing hyphen', () => {
-    expect(validateGatewayName('meta-')).toMatch(/leading or trailing hyphen/);
+    expect(validateGatewayName('copass-')).toMatch(/leading or trailing hyphen/);
   });
 
   test('rejects reserved names with the reservation reason', () => {
@@ -81,7 +81,7 @@ describe('validateGatewayName', () => {
   });
 
   test('accepts digits', () => {
-    expect(validateGatewayName('meta2')).toBeNull();
+    expect(validateGatewayName('copass2')).toBeNull();
     expect(validateGatewayName('v3')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Third stacked PR for ADR 0025. Replaces the `AlwaysAcceptVerifier` stub with a real verifier backed by `did:web` resolution and Node's built-in Ed25519. The resolver's default verifier is now the real one; `AlwaysAcceptVerifier` stays exported for tests.

**Stacked on** [#205](https://github.com/olane-labs/olane/pull/205) (resolver core). Base is the resolver-core branch — once #204 and #205 merge, GitHub auto-retargets up the stack.

## What's in this PR

**Canonicalization** (so signers and verifiers produce identical bytes):
- `src/canonical/canonicalize.ts` — RFC 8785 (JCS) subset. Sorted keys, escaped strings, no whitespace.
- `src/canonical/signing-payload.ts` — `entrySigningPayload()` / `snapshotSigningPayload()`. Strip signature/verifiedAt before canonicalizing.

**DID layer**:
- `src/did/did-document.ts` — minimal W3C DID Core model (Ed25519VerificationKey2020 only in v0).
- `src/did/multibase.ts` — base58btc + Ed25519-pub multicodec (encode + decode, ~50 lines, no deps).
- `src/did/did-web-resolver.ts` — `did:web` → HTTPS URL translation + fetch. HTTPS-only by default; `allowHttp` escape hatch for localhost in tests.
- `src/did/did-web-snapshot-verifier.ts` — `DidWebSnapshotVerifier` implements `SnapshotVerifier`. Resolves operator + maintainer DIDs, extracts Ed25519 keys from `publicKeyMultibase`, verifies signatures via `node:crypto` with SPKI-wrapped keys.

**Tests** (`test/did/`): 32 new tests covering canonicalization, multibase round-trip, `did:web` URL translation, `did:web` fetcher, real signature verification (real keys, real `node:crypto`), rejection of forged signatures and tampered payloads, DID document caching.

## Crypto choices worth a review

- **Ed25519 only in v0.** Other key types throw \`unsupported verification method type\` and the resolver drops the entry.
- **\`node:crypto\` accepts SPKI-wrapped Ed25519 keys, not raw 32-byte keys.** Inlined the 12-byte SPKI envelope construction (RFC 8410 §4) instead of pulling an ASN.1 lib.
- **Per-verifier-instance DID document cache.** A new snapshot picks up rotated keys naturally if callers construct a new verifier per snapshot lifecycle.
- **Signature failures for individual entries DROP the entry; only snapshot-level failures throw** (X.509 chain semantics — one bad operator doesn't poison the snapshot).

## Test plan

- [x] \`pnpm run build\` clean
- [x] \`pnpm run test\` — 60/60 pass (28 prior + 32 new)
- [ ] Reviewer confirms canonicalization is sufficient for the entry/snapshot shapes (no float fields, no BigInt)
- [ ] Reviewer confirms HTTPS-only posture for production \`did:web\` is desired
- [ ] Reviewer confirms the per-verifier-instance cache lifetime matches the snapshot lifecycle
- [ ] Reviewer confirms drop-on-entry-failure / throw-on-snapshot-failure split

🤖 Generated with [Claude Code](https://claude.com/claude-code)